### PR TITLE
Add API stubs for Code.org app integration covering command queue use case

### DIFF
--- a/src/js/game/PhaserApp.js
+++ b/src/js/game/PhaserApp.js
@@ -37,6 +37,45 @@ var GAME_HEIGHT = 400;
 class PhaserApp {
   constructor(phaserAppConfig) {
     /**
+     * @public {Object} codeOrgAPI - API with externally-callable methods for
+     * starting an attempt, issuing commands, etc.
+     */
+    this.codeOrgAPI = {
+      /**
+       * Called before a list of user commands will be issued.
+       */
+      startCommandCollection: () => {
+        console.log("Collecting commands.");
+      },
+      /**
+       * Called when an attempt should be started, and the entire set of
+       * command-queue API calls have been issued.
+       *
+       * @param {Function} onAttemptComplete - callback with a single parameter,
+       * "success", i.e., true if attempt was successful (level completed),
+       * false if unsuccessful (level not completed).
+       */
+      startAttempt: (onAttemptComplete) => {
+        console.log("Starting new attempt.");
+      },
+      resetAttempt: () => {
+        console.log("Resetting game.")
+      },
+      moveForward: (highlightCallback) => {
+        console.log("Adding move forward command.");
+      },
+      turnRight: (highlightCallback) => {
+        console.log("Adding turn right command.");
+      },
+      turnLeft: (highlightCallback) => {
+        console.log("Adding turn left command.");
+      },
+      destroyBlock: (highlightCallback) => {
+        console.log("Adding destroy block command.");
+      }
+    };
+
+    /**
      * Game asset file URL path
      * @property {String}
      */


### PR DESCRIPTION
Blocks defined in `code-dot-org/apps` playground:

![image](https://cloud.githubusercontent.com/assets/206973/9805224/62e19fa6-57eb-11e5-80d8-726f4d931da6.png)

Sample execution output:

![api-stubs](https://cloud.githubusercontent.com/assets/206973/9805249/c54d0644-57eb-11e5-9ba3-92dcbb9ee69c.gif)
