### PR TITLE
Add two new block APIs: getObject and whilePathAhead

### DIFF
--- a/src/js/game/PhaserApp.js
+++ b/src/js/game/PhaserApp.js
@@ -72,6 +72,13 @@ class PhaserApp {
       },
       destroyBlock(highlightCallback) {
         console.log("Adding destroy block command.");
+      },
+      getObject: function (highlightCallback) {
+        console.log("Adding 'get' command.");
+      },
+      whilePathAhead: function (highlightCallback, callback) {
+        console.log(`Adding repeat while path ahead command. Callback (with API calls):`);
+        console.log(callback);
       }
     };
 


### PR DESCRIPTION
The block `whilePathAhead` passes through a callback which can be used to trigger the block's inner API calls.

In `apps/` playground:

![while-blocks](https://cloud.githubusercontent.com/assets/206973/9828213/09dd0166-589f-11e5-9187-1a1213e8912a.gif)
