### PR TITLE
Reduce variance in code coverage metrics due to random animation timing

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "karma-coverage": "^1.1.1",
     "karma-tap": "^3.1.1",
     "istanbul": "^0.4.5",
+    "sinon": "^3.2.1",
     "tape": "^4.8.0"
   }
 }

--- a/test/integration/AdventurerTest.js
+++ b/test/integration/AdventurerTest.js
@@ -1,5 +1,8 @@
 const test = require("tape");
+const sinon = require("sinon");
 const GameController = require("../../src/js/game/GameController");
+
+sinon.stub(Math, "random").returns(0.5);
 
 const defaults = {
   assetPacks: {


### PR DESCRIPTION
Seeing some minor changes in code coverage when I wouldn't expect anything to change.  The lines are entity animations that run after delaying a random number of seconds.  Try stubbing `Math.random()` to return a consistent value to reduce variance.