### PR TITLE
Add Travis CI deploy step for publishing to GitHub Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,25 @@
 language: node_js
+
 node_js:
 - 6
+
 cache:
   directories:
     - node_modules
+
 script:
   - npm test && npm run codecov
+
 notifications:
   email: false
+
+before_deploy:
+  - npm run publish
+
+deploy:
+  local_dir: build
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  on:
+    branch: master

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -186,4 +186,11 @@ module.exports = function (grunt) {
     'aws_s3:test',
     'open:deployed'
   ]);
+
+  grunt.registerTask('publish', [
+    'clean',
+    'browserify',
+    'ejs',
+    'copy'
+  ]);
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "build/js/app.bundled.js",
   "scripts": {
     "codecov": "codecov",
+    "publish": "grunt publish",
     "test:unit": "istanbul cover tape ./test/unit/*.js --report lcovonly --dir ./coverage/unit",
     "test:integration": "karma start",
     "test": "npm run lint && npm run test:unit && npm run test:integration",


### PR DESCRIPTION
Start serving the most recent build at https://code-dot-org.github.io/craft/.  This will show the same development page as running `grunt` locally (see [README.md](https://github.com/code-dot-org/craft/blob/master/README.md#setup-your-project)).