### PR TITLE
Dynamic redstone: ship-readiness changes

### DIFF
--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1342,14 +1342,15 @@ class GameController {
       soundEffect = () => this.levelView.audioPlayer.play("fizz");
     }
 
-    this.levelView.playPlaceBlockInFrontAnimation(this.levelModel.player.position, this.levelModel.player.facing, forwardPosition, placementPlane, blockType, () => {
+    this.levelView.playPlaceBlockInFrontAnimation(this.levelModel.player.position, this.levelModel.player.facing, forwardPosition, () => {
+      this.levelModel.placeBlockForward(blockType, placementPlane);
+      this.levelView.refreshGroundPlane();
+
       this.levelModel.computeShadingPlane();
       this.levelModel.computeFowPlane();
       this.levelView.updateShadingPlane(this.levelModel.shadingPlane);
       this.levelView.updateFowPlane(this.levelModel.fowPlane);
       soundEffect();
-      this.levelModel.placeBlockForward(blockType, placementPlane);
-      this.levelView.refreshGroundPlane();
       this.delayBy(200, () => {
         this.levelView.playIdleAnimation(this.levelModel.player.position, this.levelModel.player.facing, false);
       });

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1257,13 +1257,14 @@ class GameController {
         this.levelModel.destroyBlock(blockIndex);
       }
 
-      const placedBlock = this.levelModel.placeBlock(blockType);
-      if (placedBlock) {
+      if (blockType !== "cropWheat" || this.levelModel.groundPlane.getBlockAt((this.levelModel.player.position)) === "farmlandWet") {
         if (this.checkMinecartLevelEndAnimation() && blockType === "rail") {
-          placedBlock.blockType = this.checkRailBlock(blockType);
+          blockType = this.checkRailBlock(blockType);
         }
         this.levelModel.player.updateHidingBlock(this.levelModel.player.position);
-        this.levelView.playPlaceBlockAnimation(this.levelModel.player.position, this.levelModel.player.facing, placedBlock.blockType, blockTypeAtPosition, () => {
+        this.levelView.playPlaceBlockAnimation(this.levelModel.player.position, this.levelModel.player.facing, blockType, blockTypeAtPosition, () => {
+          this.levelModel.placeBlock(blockType);
+
           this.levelModel.computeShadingPlane();
           this.levelModel.computeFowPlane();
           this.levelView.updateShadingPlane(this.levelModel.shadingPlane);

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1147,6 +1147,7 @@ class GameController {
           this.levelView.playDestroyBlockAnimation(player.position, player.facing, destroyPosition, blockType, () => {
             commandQueueItem.succeeded();
             this.levelModel.destroyBlockForward();
+            this.updateShadingPlane();
           });
         } else if (block.isUsable) {
           switch (blockType) {

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1138,8 +1138,6 @@ class GameController {
           }
           this.levelView.playDestroyBlockAnimation(player.position, player.facing, destroyPosition, blockType, () => {
             commandQueueItem.succeeded();
-            this.levelModel.destroyBlockForward();
-            this.updateShadingPlane();
           });
         } else if (block.isUsable) {
           switch (blockType) {

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1181,8 +1181,6 @@ class GameController {
       return;
     }
     let block = this.levelModel.actionPlane[this.levelModel.yToIndex(position[1]) + position[0]];
-    // clear the block in level model (block info in 2d grid)
-    this.levelModel.destroyBlock(position);
 
     if (block !== null && block !== undefined) {
       let destroyPosition = position;
@@ -1225,6 +1223,9 @@ class GameController {
         }
       }
     }
+
+    // clear the block in level model (block info in 2d grid)
+    this.levelModel.destroyBlock(position);
   }
 
   checkTntAnimation() {

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1260,12 +1260,14 @@ class GameController {
       }
 
       if (blockType !== "cropWheat" || this.levelModel.groundPlane.getBlockAt((this.levelModel.player.position)) === "farmlandWet") {
-        if (this.checkMinecartLevelEndAnimation() && blockType === "rail") {
-          blockType = this.checkRailBlock(blockType);
-        }
         this.levelModel.player.updateHidingBlock(this.levelModel.player.position);
         this.levelView.playPlaceBlockAnimation(this.levelModel.player.position, this.levelModel.player.facing, blockType, blockTypeAtPosition, () => {
-          this.levelModel.placeBlock(blockType);
+          let force = false;
+          if (this.checkMinecartLevelEndAnimation() && blockType === "rail") {
+            blockType = this.checkRailBlock(blockType);
+            force = true;
+          }
+          this.levelModel.placeBlock(blockType, force);
 
           this.levelModel.computeShadingPlane();
           this.levelModel.computeFowPlane();

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1249,7 +1249,7 @@ class GameController {
         this.levelModel.destroyBlock(blockIndex);
       }
 
-      if (blockType !== "cropWheat" || this.levelModel.groundPlane.getBlockAt((this.levelModel.player.position)) === "farmlandWet") {
+      if (blockType !== "cropWheat" || this.levelModel.groundPlane.getBlockAt((this.levelModel.player.position)).blockType === "farmlandWet") {
         this.levelModel.player.updateHidingBlock(this.levelModel.player.position);
         this.levelView.playPlaceBlockAnimation(this.levelModel.player.position, this.levelModel.player.facing, blockType, blockTypeAtPosition, () => {
           let force = false;

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -795,7 +795,7 @@ module.exports = class LevelModel {
     this.moveForward();
   }
 
-  placeBlock(blockType) {
+  placeBlock(blockType, force = false) {
     const position = this.player.position;
     let shouldPlace = false;
     let placedBlock = null;
@@ -813,7 +813,7 @@ module.exports = class LevelModel {
     if (shouldPlace === true) {
       var block = new LevelBlock(blockType);
 
-      placedBlock = this.actionPlane.setBlockAt(position, block);
+      placedBlock = this.actionPlane.setBlockAt(position, block, {}, force);
       this.player.isOnBlock = !block.isWalkable;
     }
 

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -841,7 +841,7 @@ module.exports = class LevelModel {
         block.position = [x, y];
 
         if (block.isDestroyable) {
-          this.actionPlane.setBlockAt(position, new LevelBlock(""));
+          this.actionPlane.setBlockAt(position, new LevelBlock(""), block);
         }
       }
     }
@@ -859,7 +859,7 @@ module.exports = class LevelModel {
       if (block !== null) {
 
         if (block.isDestroyable) {
-          this.actionPlane.setBlockAt(blockForwardPosition, new LevelBlock(""));
+          this.actionPlane.setBlockAt(blockForwardPosition, new LevelBlock(""), block);
         }
       }
     }

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -49,10 +49,6 @@ module.exports = class LevelPlane extends Array {
           }
         }
       });
-      if (this.levelModel) {
-        this.levelModel.controller.levelView.refreshActionPlane(this.levelModel,
-          [this.coordinatesToIndex(position)]);
-      }
     }
 
     if (block.blockType === "") {
@@ -60,16 +56,17 @@ module.exports = class LevelPlane extends Array {
         const orthogonalBlock = this.getBlockAt(orthogonalPosition);
         if (orthogonalBlock && orthogonalBlock.isRedstone) {
           this.determineRedstoneSprite(orthogonalPosition);
-          if (this.levelModel) {
-            this.levelModel.controller.levelView.refreshActionPlane(
-              this.levelModel, [this.coordinatesToIndex(orthogonalPosition)]);
-          }
         }
       });
     }
 
     if (block.isRail) {
       block.blockType = this.determineRailType(position);
+    }
+
+    if (this.levelModel) {
+      this.levelModel.controller.levelView.refreshActionPlane(this.levelModel,
+        [this.coordinatesToIndex(position)]);
     }
 
     return block;

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -34,7 +34,7 @@ module.exports = class LevelPlane extends Array {
     }
   }
 
-  setBlockAt(position, block, oldBlock = {}) {
+  setBlockAt(position, block, oldBlock = {}, force = false) {
     this[this.coordinatesToIndex(position)] = block;
 
     if (block.isRedstone) {
@@ -62,7 +62,7 @@ module.exports = class LevelPlane extends Array {
       });
     }
 
-    if (block.isRail) {
+    if (block.isRail && !force) {
       block.blockType = this.determineRailType(position);
     }
 

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -34,11 +34,13 @@ module.exports = class LevelPlane extends Array {
     }
   }
 
-  setBlockAt(position, block) {
+  setBlockAt(position, block, oldBlock = {}) {
     this[this.coordinatesToIndex(position)] = block;
 
     if (block.isRedstone) {
       this.determineRedstoneSprite(position);
+    }
+    if (block.isRedstone || oldBlock.isRedstone) {
       this.getOrthogonalPositions(position).forEach(orthogonalPosition => {
         const orthogonalBlock = this.getBlockAt(orthogonalPosition);
         if (orthogonalBlock && orthogonalBlock.isRedstone) {

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -876,17 +876,14 @@ module.exports = class LevelView {
     let destroyOverlay = this.actionPlane.create(-12 + 40 * destroyPosition[0], -22 + 40 * destroyPosition[1], "destroyOverlay", "destroy1");
     destroyOverlay.sortOrder = this.yToIndex(destroyPosition[1]) + 2;
     this.onAnimationEnd(destroyOverlay.animations.add("destroy", Phaser.Animation.generateFrameNames("destroy", 1, 12, "", 0), 30, false), () => {
-      this.actionPlaneBlocks[blockIndex] = null;
-
       if (blockToDestroy.hasOwnProperty("onBlockDestroy")) {
         blockToDestroy.onBlockDestroy(blockToDestroy);
       }
 
-      blockToDestroy.kill();
       destroyOverlay.kill();
-      this.toDestroy.push(blockToDestroy);
       this.toDestroy.push(destroyOverlay);
 
+      this.controller.levelModel.destroyBlockForward();
       this.controller.updateShadingPlane();
       this.controller.updateFowPlane();
 

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -737,7 +737,7 @@ module.exports = class LevelView {
     var jumpAnimName;
     let blockIndex = this.yToIndex(position[1]) + position[0];
 
-    if (blockType === "cropWheat" || blockType === "torch" || blockType.substring(0, 5) === "rails") {
+    if (blockType === "cropWheat" || blockType === "torch" || blockType.startsWith("rails") || blockType.startsWith("redstoneWire")) {
       this.setSelectionIndicatorPosition(position[0], position[1]);
 
       var signalDetacher = this.playPlayerAnimation("punch", position, facing, false).onComplete.add(() => {

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -790,16 +790,10 @@ module.exports = class LevelView {
     }
   }
 
-  playPlaceBlockInFrontAnimation(playerPosition, facing, blockPosition, plane, blockType, completionHandler) {
+  playPlaceBlockInFrontAnimation(playerPosition, facing, blockPosition, completionHandler) {
     this.setSelectionIndicatorPosition(blockPosition[0], blockPosition[1]);
 
     this.playPlayerAnimation("punch", playerPosition, facing, false).onComplete.addOnce(() => {
-      if (plane === this.controller.levelModel.actionPlane) {
-        this.createActionPlaneBlock(blockPosition, blockType);
-      } else {
-        // re-lay ground tiles based on model
-        this.refreshGroundPlane();
-      }
       completionHandler();
     });
   }

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -737,7 +737,7 @@ module.exports = class LevelView {
     var jumpAnimName;
     let blockIndex = this.yToIndex(position[1]) + position[0];
 
-    if (blockType === "cropWheat" || blockType === "torch" || blockType.startsWith("rails") || blockType.startsWith("redstoneWire")) {
+    if (blockType === "cropWheat" || blockType === "torch" || blockType.startsWith("rail") || blockType.startsWith("redstoneWire")) {
       this.setSelectionIndicatorPosition(position[0], position[1]);
 
       var signalDetacher = this.playPlayerAnimation("punch", position, facing, false).onComplete.add(() => {

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -741,16 +741,7 @@ module.exports = class LevelView {
       this.setSelectionIndicatorPosition(position[0], position[1]);
 
       var signalDetacher = this.playPlayerAnimation("punch", position, facing, false).onComplete.add(() => {
-        var sprite;
         signalDetacher.detach();
-        let blockIndex = (this.yToIndex(position[1])) + position[0];
-        sprite = this.createBlock(this.actionPlane, position[0], position[1], blockType);
-
-        if (sprite) {
-          sprite.sortOrder = this.yToIndex(position[1]);
-        }
-
-        this.actionPlaneBlocks[blockIndex] = sprite;
         completionHandler();
       });
     } else {
@@ -777,13 +768,6 @@ module.exports = class LevelView {
         if (blockTypeAtPosition !== "") {
           this.actionPlaneBlocks[blockIndex].kill();
         }
-        var sprite = this.createBlock(this.actionPlane, position[0], position[1], blockType);
-
-        if (sprite) {
-          sprite.sortOrder = this.yToIndex(position[1]);
-        }
-
-        this.actionPlaneBlocks[blockIndex] = sprite;
         completionHandler();
       });
       placementTween.start();


### PR DESCRIPTION
Fixes a few remaining issues:

 - Newly-placed blocks have the correct shadow.
 - Don't jump up a block height when placing redstone wires.
 - Fix stale sprites after destroying redstone wires.
 - Prevent double-updating the view in `playPlaceBlockInFrontAnimation`/`playPlaceBlockAnimation` followed by `setBlockAt`.

After this PR I think we're ready to ship!