### PR TITLE
Add Designer level 7 integration test, also scale `wait` by timeScale

### DIFF
--- a/src/js/game/Entities/BaseEntity.js
+++ b/src/js/game/Entities/BaseEntity.js
@@ -55,7 +55,7 @@ module.exports = class BaseEntity {
             });
 
             tween.start();
-        }, 50);
+        }, 50 / this.controller.tweenTimeScale);
         // smooth movement using tween
 
     }

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -917,7 +917,7 @@ class GameController {
     if (!this.isType(target)) {
       let entity = this.getEntity(target);
       this.addCommandRecord("wait", entity.type, commandQueueItem.repeat);
-      setTimeout(() => { commandQueueItem.succeeded(); }, time * 1000);
+      setTimeout(() => { commandQueueItem.succeeded(); }, time * 1000 / this.tweenTimeScale);
     } else {
       let entities = this.getEntities(target);
       for (let i = 0; i < entities.length; i++) {

--- a/test/helpers/DesignerLevels.js
+++ b/test/helpers/DesignerLevels.js
@@ -105,4 +105,25 @@ module.exports = {
       return cowOnGrassCount >= 2;
     },
   },
+  designer07: {
+    isEventLevel: true,
+    isDaytime: false,
+    groundPlane: ["stone", "stone", "stone", "stone", "lava", "lava", "stone", "grass", "grass", "grass", "stone", "stone", "stone", "stone", "lava", "lava", "stone", "grass", "grass", "grass", "stone", "stone", "stone", "stone", "stone", "lava", "stone", "grass", "grass", "grass", "gravel", "stone", "stone", "stone", "stone", "stone", "stone", "grass", "grass", "grass", "stone", "stone", "gravel", "gravel", "gravel", "gravel", "gravel", "dirtCoarse", "dirtCoarse", "dirtCoarse", "stone", "gravel", "gravel", "stone", "gravel", "gravel", "gravel", "dirtCoarse", "dirtCoarse", "dirtCoarse", "gravel", "gravel", "gravel", "stone", "stone", "stone", "stone", "grass", "grass", "grass", "stone", "gravel", "stone", "stone", "stone", "stone", "stone", "grass", "grass", "grass", "lava", "stone", "stone", "stone", "stone", "stone", "stone", "grass", "grass", "grass", "lava", "lava", "stone", "gravel", "stone", "stone", "stone", "grass", "grass", "grass"],
+    groundDecorationPlane: ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "lavaPop", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "tallGrass", "", "lavaPop", "", "", "", "", "", "", "", ""],
+    actionPlane: ["stone", "stone", "", "", "stone", "stone", "stone", "oreCoal", "stone", "stone", "oreCoal", "stone", "", "", "", "", "stone", "stone", "stone", "", "stone", "", "", "", "", "", "stone", "stone", "", "treeBirch", "", "", "", "", "", "", "stone", "stone", "", "", "", "", "", "", "", "", "stone", "", "", "", "", "", "", "", "", "", "stone", "", "", "", "", "", "", "", "", "", "stone", "stone", "", "", "", "", "", "", "", "stone", "stone", "stone", "", "", "", "", "", "", "stone", "stone", "stone", "stone", "stone", "", "", "", "", "", "stone", "stone", "stone", "oreDiamond", "stone", "stone"],
+    entities: [["sheep", 8, 4, 1], ["creeper", 2, 8, 1]],
+    usePlayer: true,
+    playerStartPosition: [3, 1],
+    playerStartDirection: 2,
+    levelVerificationTimeout: 40000,
+    timeoutResult: () => false,
+    verificationFunction: verificationAPI  => {
+      const successPositions = [[7, 4] , [7, 5]];
+      for (let i = 0; i < successPositions.length; i++) {
+        if (verificationAPI.isEntityAt("Player" , successPositions[i])) {
+          return true;
+        }
+      }
+    },
+  },
 };

--- a/test/helpers/DesignerLevels.js
+++ b/test/helpers/DesignerLevels.js
@@ -115,7 +115,7 @@ module.exports = {
     usePlayer: true,
     playerStartPosition: [3, 1],
     playerStartDirection: 2,
-    levelVerificationTimeout: 40000,
+    levelVerificationTimeout: -1,
     timeoutResult: () => false,
     verificationFunction: verificationAPI  => {
       const successPositions = [[7, 4] , [7, 5]];

--- a/test/helpers/RunLevel.js
+++ b/test/helpers/RunLevel.js
@@ -28,7 +28,7 @@ module.exports = (level, commands) => {
       play: () => {},
     },
     debug: false,
-    customSlowMotion: 0.1,
+    customSlowMotion: 0.2,
     afterAssetsLoaded: () => {
       const api = gameController.codeOrgAPI;
       api.resetAttempt();

--- a/test/helpers/RunLevel.js
+++ b/test/helpers/RunLevel.js
@@ -18,7 +18,7 @@ const defaults = {
   playerStartPosition: [],
 };
 
-module.exports = (level, commands) => {
+module.exports = (level, commands, step = 0.1) => {
   const gameController = new GameController({
     forceSetTimeOut: true,
     Phaser: window.Phaser,
@@ -28,7 +28,7 @@ module.exports = (level, commands) => {
       play: () => {},
     },
     debug: false,
-    customSlowMotion: 0.2,
+    customSlowMotion: step,
     afterAssetsLoaded: () => {
       const api = gameController.codeOrgAPI;
       api.resetAttempt();

--- a/test/integration/DesignerTest.js
+++ b/test/integration/DesignerTest.js
@@ -194,7 +194,8 @@ test('Designer 7: Explode Stone Wall', t => {
       api.moveForward(null, 'Player');
     }
 
-    api.startAttempt(success => {
+    api.startAttempt((success, levelModel) => {
+      t.deepEqual(levelModel.player.position, [7, 4]);
       t.assert(success);
       t.end();
 

--- a/test/integration/DesignerTest.js
+++ b/test/integration/DesignerTest.js
@@ -200,5 +200,5 @@ test('Designer 7: Explode Stone Wall', t => {
 
       resolve();
     });
-  }));
+  }), 0.5);
 });

--- a/test/integration/DesignerTest.js
+++ b/test/integration/DesignerTest.js
@@ -151,7 +151,7 @@ test('Designer 6: Lead Cows to Grass', t => {
   }));
 });
 
-test.only('Designer 7: Explode Stone Wall', t => {
+test('Designer 7: Explode Stone Wall', t => {
   attempt('designer07', api => new Promise(resolve => {
     // Make the creeper move towards the sheep.
     api.onEventTriggered(null, 'creeper', 2, event => {
@@ -168,11 +168,12 @@ test.only('Designer 7: Explode Stone Wall', t => {
     // Define creeper explode behavior as user code.
     api.onEventTriggered(null, 'creeper', 0, event => {
       api.flashEntity(null, event.targetIdentifier);
+      api.wait(null, '2', event.targetIdentifier);
       api.explodeEntity(null, event.targetIdentifier);
     });
 
     // Move player to touch the creeper, then away.
-    api.wait(null, '3', 'Player');
+    api.wait(null, '5', 'Player');
     api.moveForward(null, 'Player');
     api.moveForward(null, 'Player');
     api.turnLeft(null, 'Player');
@@ -184,7 +185,7 @@ test.only('Designer 7: Explode Stone Wall', t => {
     api.turnRight(null, 'Player');
     api.moveForward(null, 'Player');
     api.moveForward(null, 'Player');
-    api.wait(null, '2', 'Player');
+    api.wait(null, '5', 'Player');
 
     // Move player to the sheep.
     api.turnLeft(null, 'Player');

--- a/test/integration/DesignerTest.js
+++ b/test/integration/DesignerTest.js
@@ -150,3 +150,54 @@ test('Designer 6: Lead Cows to Grass', t => {
     });
   }));
 });
+
+test.only('Designer 7: Explode Stone Wall', t => {
+  attempt('designer07', api => new Promise(resolve => {
+    // Make the creeper move towards the sheep.
+    api.onEventTriggered(null, 'creeper', 2, event => {
+      api.turnLeft(null, event.targetIdentifier);
+      api.moveForward(null, event.targetIdentifier);
+      api.moveForward(null, event.targetIdentifier);
+      api.moveForward(null, event.targetIdentifier);
+      api.turnRight(null, event.targetIdentifier);
+      api.moveForward(null, event.targetIdentifier);
+      api.moveForward(null, event.targetIdentifier);
+      api.moveForward(null, event.targetIdentifier);
+    });
+
+    // Define creeper explode behavior as user code.
+    api.onEventTriggered(null, 'creeper', 0, event => {
+      api.flashEntity(null, event.targetIdentifier);
+      api.explodeEntity(null, event.targetIdentifier);
+    });
+
+    // Move player to touch the creeper, then away.
+    api.wait(null, '3', 'Player');
+    api.moveForward(null, 'Player');
+    api.moveForward(null, 'Player');
+    api.turnLeft(null, 'Player');
+    api.moveForward(null, 'Player');
+    api.moveForward(null, 'Player');
+    api.turnRight(null, 'Player');
+    api.moveForward(null, 'Player');
+    api.moveForward(null, 'Player');
+    api.turnRight(null, 'Player');
+    api.moveForward(null, 'Player');
+    api.moveForward(null, 'Player');
+    api.wait(null, '2', 'Player');
+
+    // Move player to the sheep.
+    api.turnLeft(null, 'Player');
+    api.turnLeft(null, 'Player');
+    for (let i = 0; i < 5; i++) {
+      api.moveForward(null, 'Player');
+    }
+
+    api.startAttempt(success => {
+      t.assert(success);
+      t.end();
+
+      resolve();
+    });
+  }));
+});

--- a/test/integration/DesignerTest.js
+++ b/test/integration/DesignerTest.js
@@ -185,12 +185,13 @@ test('Designer 7: Explode Stone Wall', t => {
     api.turnRight(null, 'Player');
     api.moveForward(null, 'Player');
     api.moveForward(null, 'Player');
+    api.moveForward(null, 'Player');
     api.wait(null, '5', 'Player');
 
     // Move player to the sheep.
     api.turnLeft(null, 'Player');
     api.turnLeft(null, 'Player');
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 6; i++) {
       api.moveForward(null, 'Player');
     }
 
@@ -201,5 +202,5 @@ test('Designer 7: Explode Stone Wall', t => {
 
       resolve();
     });
-  }), 0.5);
+  }), 1);
 });


### PR DESCRIPTION
All tweens and animations are played at different speeds controlled by the `customSlowMotion` param. However the `wait` block and the small pauses in Creeper animations are controlled by setTimeout. Take into account the timeScale, so when running faster or slower these pauses are adjusted by the correct amount.