### PR TITLE
Minecart animation fix

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1160,7 +1160,7 @@ module.exports = class LevelView {
         const newBlock = this.controller.levelModel.actionPlane.getBlockAt(position);
         if (newBlock && newBlock.blockType) {
           this.createActionPlaneBlock(position, newBlock.blockType);
-        } else {
+        } else if (newBlock) {
           // Remove the old sprite at this position, if there is one.
           const index = this.coordinatesToIndex(position);
           this.actionPlane.remove(this.actionPlaneBlocks[index]);

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -497,7 +497,7 @@ module.exports = class LevelView {
       y: (-32 + 40 * nextPosition[1]),
     }, speed, Phaser.Easing.Linear.None);
     tween.start();
-    this.player.sprite.sortOrder = this.yToIndex(nextPosition[1]) + 5;
+    this.player.sprite.sortOrder = this.yToIndex(nextPosition[1]) + 10;
 
     return tween;
   }
@@ -538,14 +538,11 @@ module.exports = class LevelView {
       //turn
       if (arraydirection.substring(0, 4) === "turn") {
         direction = arraydirection.substring(5);
-        this.playMinecartTurnAnimation(position, facing, isOnBlock, completionHandler, direction).onComplete.add(() => {
-          this.playMinecartMoveForwardAnimation(position, facing, isOnBlock, completionHandler, nextPosition, speed).onComplete.add(() => {
-            position = nextPosition;
-            this.playTrack(position, facing, isOnBlock, completionHandler, minecartTrack);
-          });
+        this.onAnimationEnd(this.playMinecartTurnAnimation(position, facing, isOnBlock, completionHandler, direction), () => {
+          this.playTrack(position, facing, isOnBlock, completionHandler, minecartTrack);
         });
       } else {
-        this.playMinecartMoveForwardAnimation(position, facing, isOnBlock, completionHandler, nextPosition, speed).onComplete.add(() => {
+        this.onAnimationEnd(this.playMinecartMoveForwardAnimation(position, facing, isOnBlock, completionHandler, nextPosition, speed), () => {
           this.playTrack(position, facing, isOnBlock, completionHandler, minecartTrack);
         });
       }

--- a/src/test-build-only/levels.js
+++ b/src/test-build-only/levels.js
@@ -53,7 +53,7 @@ window.demoLevels = {
       "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
       "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
       "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
-      "grass", "grass", "grass", "dirtCoarse", "dirtCoarse", "dirtCoarse", "grass", "grass", "grass", "grass",
+      "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
       "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
       "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
       "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
@@ -76,10 +76,10 @@ window.demoLevels = {
 
     actionPlane: [
       "", "", "", "", "", "", "", "", "", "",
-      "", "", "", "", "", "", "", "", "", "",
-      "", "", "", "", "", "", "", "", "", "",
-      "", "", "", "", "", "", "", "", "", "",
-      "", "", "", "", "", "", "", "", "", "",
+      "", "", "railsSouthEast", "railsEastWest", "railsEastWest", "railsSouthWest", "", "", "", "",
+      "", "", "railsNorthSouth", "", "", "railsNorthSouth", "", "", "", "",
+      "", "", "railsNorthSouth", "", "", "railsNorthSouth", "", "", "", "",
+      "", "", "railsNorthEast", "railsEastWest", "railsEastWest", "railsNorthWest", "", "", "", "",
       "", "", "", "", "", "", "", "", "", "",
       "", "", "", "", "", "", "", "", "", "",
       "", "", "", "", "", "", "", "", "", "",


### PR DESCRIPTION
Use `onAnimationEnd` instead of `onComplete` to play minecart animation.  Fixes jumps in playback when running `LevelView.prototype.playTrack` with more than 1 turn.

![minecart](https://user-images.githubusercontent.com/413693/29981651-5aa6e3d6-8f03-11e7-9bff-edae2a8a50b4.gif)