### PR TITLE
Cleanup player offset magic numbers

### DIFF
--- a/src/js/game/Entities/Player.js
+++ b/src/js/game/Entities/Player.js
@@ -70,7 +70,7 @@ module.exports = class Player extends BaseEntity {
       groundType = levelModel.groundPlane[levelModel.yToIndex(player.position[1]) + player.position[0]].blockType;
     }
 
-    levelView.playMoveForwardAnimation(player.position, player.facing, jumpOff, player.isOnBlock, groundType, () => {
+    levelView.playMoveForwardAnimation(player.position, prevPosition, player.facing, jumpOff, player.isOnBlock, groundType, () => {
       levelView.playIdleAnimation(player.position, player.facing, player.isOnBlock);
 
       if (levelModel.isPlayerStandingInWater()) {

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1411,7 +1411,7 @@ class GameController {
               }
             }
             if (!player.isOnBlock && wasOnBlock) {
-              this.levelView.playPlayerJumpDownVerticalAnimation(player.position, player.facing);
+              this.levelView.playPlayerJumpDownVerticalAnimation(player.position, player.position, player.facing);
             }
             this.levelModel.computeShadingPlane();
             this.levelModel.computeFowPlane();

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1411,7 +1411,7 @@ class GameController {
               }
             }
             if (!player.isOnBlock && wasOnBlock) {
-              this.levelView.playPlayerJumpDownVerticalAnimation(player.position, player.position, player.facing);
+              this.levelView.playPlayerJumpDownVerticalAnimation(player.facing, player.position);
             }
             this.levelModel.computeShadingPlane();
             this.levelModel.computeFowPlane();

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -684,20 +684,7 @@ module.exports = class LevelView {
       tween = this.addResettableTween(this.player.sprite).to(
         this.positionToScreen(position, isOnBlock), 180, Phaser.Easing.Linear.None);
     } else {
-      animName = "jumpDown" + direction;
-      this.playScaledSpeed(this.player.sprite.animations, animName);
-      const start = this.positionToScreen(oldPosition);
-      const end = this.positionToScreen(position);
-      tween = this.addResettableTween(this.player.sprite).to({
-        x: [start.x, end.x, end.x],
-        y: [start.y, end.y - 50, end.y],
-      }, 300, Phaser.Easing.Linear.None).interpolation((v, k) => {
-        return Phaser.Math.bezierInterpolation(v, k);
-      });
-
-      tween.onComplete.add(() => {
-        this.audioPlayer.play("fall");
-      });
+      tween = this.playPlayerJumpDownVerticalAnimation(position, oldPosition, direction);
     }
 
     tween.onComplete.add(() => {
@@ -705,8 +692,6 @@ module.exports = class LevelView {
     });
 
     tween.start();
-
-    return tween;
   }
 
   playPlayerJumpDownVerticalAnimation(position, oldPosition, direction) {
@@ -724,6 +709,8 @@ module.exports = class LevelView {
       this.audioPlayer.play("fall");
     });
     tween.start();
+
+    return tween;
   }
 
   playPlaceBlockAnimation(position, facing, blockType, blockTypeAtPosition, completionHandler) {
@@ -1052,7 +1039,7 @@ module.exports = class LevelView {
     return {
       x: -18 + 40 * x,
       y: -32 + (isOnBlock ? -23 : 0) + 40 * y,
-    }
+    };
   }
 
   setPlayerPosition(x, y, isOnBlock) {

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -665,13 +665,10 @@ module.exports = class LevelView {
   }
 
   playMoveForwardAnimation(position, oldPosition, facing, shouldJumpDown, isOnBlock, groundType, completionHandler) {
-    var tween,
-      animName;
+    let tween;
 
     //stepping on stone sfx
     this.playBlockSound(groundType);
-
-    let direction = this.getDirectionName(facing);
 
     this.setSelectionIndicatorPosition(position[0], position[1]);
     //make sure to render high for when moving up after placing a block
@@ -679,12 +676,12 @@ module.exports = class LevelView {
     this.player.sprite.sortOrder = this.yToIndex(zOrderYIndex) + 5;
 
     if (!shouldJumpDown) {
-      animName = "walk" + direction;
+      const animName = "walk" + this.getDirectionName(facing);
       this.playScaledSpeed(this.player.sprite.animations, animName);
       tween = this.addResettableTween(this.player.sprite).to(
         this.positionToScreen(position, isOnBlock), 180, Phaser.Easing.Linear.None);
     } else {
-      tween = this.playPlayerJumpDownVerticalAnimation(position, oldPosition, direction);
+      tween = this.playPlayerJumpDownVerticalAnimation(facing, position, oldPosition);
     }
 
     tween.onComplete.add(() => {
@@ -694,9 +691,17 @@ module.exports = class LevelView {
     tween.start();
   }
 
-  playPlayerJumpDownVerticalAnimation(position, oldPosition, direction) {
-    var animName = "jumpDown" + direction;
+  /**
+   * Animate the player jumping down from on top of a block to ground level.
+   * @param {FacingDirection} facing
+   * @param {Array<int>}position
+   * @param {?Array<int>} oldPosition
+   * @return {Phaser.Tween}
+   */
+  playPlayerJumpDownVerticalAnimation(facing, position, oldPosition = position) {
+    var animName = "jumpDown" + this.getDirectionName(facing);
     this.playScaledSpeed(this.player.sprite.animations, animName);
+
     const start = this.positionToScreen(oldPosition);
     const end = this.positionToScreen(position);
     const tween = this.addResettableTween(this.player.sprite).to({
@@ -1034,6 +1039,12 @@ module.exports = class LevelView {
     tween.start();
   }
 
+  /**
+   * Convert a grid coordinate position to a screen X/Y location.
+   * @param {Array<int>} position
+   * @param {?boolean} isOnBlock
+   * @return {{x: number, y: number}}
+   */
   positionToScreen(position, isOnBlock = false) {
     const [x, y] = position;
     return {

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -666,9 +666,8 @@ module.exports = class LevelView {
     }
   }
 
-  playMoveForwardAnimation(position, facing, shouldJumpDown, isOnBlock, groundType, completionHandler) {
+  playMoveForwardAnimation(position, oldPosition, facing, shouldJumpDown, isOnBlock, groundType, completionHandler) {
     var tween,
-      oldPosition,
       newPosVec,
       animName,
       yOffset = -32;
@@ -682,7 +681,6 @@ module.exports = class LevelView {
     //make sure to render high for when moving up after placing a block
     var zOrderYIndex = position[1] + (facing === FacingDirection.Up ? 1 : 0);
     this.player.sprite.sortOrder = this.yToIndex(zOrderYIndex) + 5;
-    oldPosition = [Math.trunc((this.player.sprite.position.x + 18) / 40), Math.ceil((this.player.sprite.position.y + 32) / 40)];
     newPosVec = [position[0] - oldPosition[0], position[1] - oldPosition[1]];
 
     //change offset for moving on top of blocks

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -681,7 +681,6 @@ module.exports = class LevelView {
     //make sure to render high for when moving up after placing a block
     var zOrderYIndex = position[1] + (facing === FacingDirection.Up ? 1 : 0);
     this.player.sprite.sortOrder = this.yToIndex(zOrderYIndex) + 5;
-    newPosVec = [position[0] - oldPosition[0], position[1] - oldPosition[1]];
 
     //change offset for moving on top of blocks
     if (isOnBlock) {
@@ -699,8 +698,8 @@ module.exports = class LevelView {
       animName = "jumpDown" + direction;
       this.playScaledSpeed(this.player.sprite.animations, animName);
       tween = this.addResettableTween(this.player.sprite).to({
-        x: [-18 + 40 * oldPosition[0], -18 + 40 * (oldPosition[0] + newPosVec[0]), -18 + 40 * position[0]],
-        y: [-32 + 40 * oldPosition[1], -32 + 40 * (oldPosition[1] + newPosVec[1]) - 50, -32 + 40 * position[1]]
+        x: [-18 + 40 * oldPosition[0], -18 + 40 * position[0], -18 + 40 * position[0]],
+        y: [-32 + 40 * oldPosition[1], -32 + 40 * position[1] - 50, -32 + 40 * position[1]]
       }, 300, Phaser.Easing.Linear.None).interpolation((v, k) => {
         return Phaser.Math.bezierInterpolation(v, k);
       });


### PR DESCRIPTION
The Agent character will have different default offsets than the player.  Extract a `positionToScreen` helper so the x and y offsets all live in one place.

There should be no functional difference from this change.