### PR TITLE
Don't inherit from Array

### DIFF
--- a/src/js/game/Entities/BaseEntity.js
+++ b/src/js/game/Entities/BaseEntity.js
@@ -139,7 +139,7 @@ module.exports = class BaseEntity {
         var prevPosition = this.position;
         this.position = forwardPosition;
         // play sound effect
-        let groundType = levelModel.groundPlane[levelModel.yToIndex(this.position[1]) + this.position[0]].blockType;
+        let groundType = levelModel.groundPlane._data[levelModel.yToIndex(this.position[1]) + this.position[0]].blockType;
         // play move forward animation and play idle after that
         this.playMoveForwardAnimation(forwardPosition, this.facing, commandQueueItem, groundType, () => {
         });

--- a/src/js/game/Entities/Player.js
+++ b/src/js/game/Entities/Player.js
@@ -65,9 +65,9 @@ module.exports = class Player extends BaseEntity {
 
     jumpOff = wasOnBlock && wasOnBlock !== player.isOnBlock;
     if (player.isOnBlock || jumpOff) {
-      groundType = levelModel.actionPlane[levelModel.yToIndex(player.position[1]) + player.position[0]].blockType;
+      groundType = levelModel.actionPlane._data[levelModel.yToIndex(player.position[1]) + player.position[0]].blockType;
     } else {
-      groundType = levelModel.groundPlane[levelModel.yToIndex(player.position[1]) + player.position[0]].blockType;
+      groundType = levelModel.groundPlane._data[levelModel.yToIndex(player.position[1]) + player.position[0]].blockType;
     }
 
     levelView.playMoveForwardAnimation(player.position, prevPosition, player.facing, jumpOff, player.isOnBlock, groundType, () => {

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1098,7 +1098,7 @@ class GameController {
     let frontPosition = this.levelModel.getMoveForwardPosition(player);
     let frontEntity = this.levelEntity.getEntityAt(frontPosition);
     const frontIndex = this.levelModel.yToIndex(frontPosition[1]) + frontPosition[0];
-    let frontBlock = this.levelModel.actionPlane[frontIndex];
+    let frontBlock = this.levelModel.actionPlane._data[frontIndex];
     const isFrontBlockDoor = frontBlock === undefined ? false : frontBlock.blockType === "door";
     if (frontEntity !== null) {
       // push use command to execute general use behavior of the entity before executing the event
@@ -1218,7 +1218,7 @@ class GameController {
     if (!this.levelModel.inBounds(position[0], position[1])) {
       return;
     }
-    let block = this.levelModel.actionPlane[this.levelModel.yToIndex(position[1]) + position[0]];
+    let block = this.levelModel.actionPlane._data[this.levelModel.yToIndex(position[1]) + position[0]];
 
     if (block !== null && block !== undefined) {
       let destroyPosition = position;
@@ -1280,7 +1280,7 @@ class GameController {
 
   placeBlock(commandQueueItem, blockType) {
     let blockIndex = (this.levelModel.yToIndex(this.levelModel.player.position[1]) + this.levelModel.player.position[0]);
-    let blockTypeAtPosition = this.levelModel.actionPlane[blockIndex].blockType;
+    let blockTypeAtPosition = this.levelModel.actionPlane._data[blockIndex].blockType;
     if (this.levelModel.canPlaceBlock()) {
       if (blockTypeAtPosition !== "") {
         this.levelModel.destroyBlock(blockIndex);

--- a/src/js/game/LevelMVC/AStarPathFinding.js
+++ b/src/js/game/LevelMVC/AStarPathFinding.js
@@ -7,7 +7,7 @@ module.exports = class AStarPathFinding {
 
   createGrid() {
     let tempGrid = [];
-    for (let i = 0; i < this.levelModel.actionPlane.length; i++) {
+    for (let i = 0; i < this.levelModel.actionPlane._data.length; i++) {
       let coordinates = this.levelModel.indexToXY(i);
       // Push node objects.
       tempGrid.push({
@@ -41,7 +41,7 @@ module.exports = class AStarPathFinding {
   getNode(position) {
     const index = this.levelModel.coordinatesToIndex(position);
     if (this.levelModel.inBounds(position[0], position[1]) &&   // is the node within bounds
-        this.levelModel.actionPlane[index].isEmpty &&           // is the node empty
+        this.levelModel.actionPlane._data[index].isEmpty &&           // is the node empty
         !this.grid[index].closed) {                             // has the node already been processed.
       return this.grid[index];
     }

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -35,14 +35,14 @@ module.exports = class LevelModel {
     this.shadingPlane = [];
     this.actionPlane = new LevelPlane(this.initialLevelData.actionPlane, this.planeWidth, this.planeHeight, this.controller, this, true);
 
-    for (let i = 0; i < this.actionPlane.length; ++i) {
-      if (this.actionPlane[i].blockType === "railsRedstoneTorch") {
+    for (let i = 0; i < this.actionPlane._data.length; ++i) {
+      if (this.actionPlane._data[i].blockType === "railsRedstoneTorch") {
         let position = this.actionPlane.indexToCoordinates(i);
         this.actionPlane.redstonePropagation(position);
       }
     }
-    for (let i = 0; i < this.actionPlane.length; ++i) {
-      if (this.actionPlane[i].blockType.substring(0,12) === "redstoneWire") {
+    for (let i = 0; i < this.actionPlane._data.length; ++i) {
+      if (this.actionPlane._data[i].blockType.substring(0,12) === "redstoneWire") {
         let y = Math.floor(i / this.planeHeight);
         let x = i - (y * this.planeHeight);
         let position = [x,y];
@@ -62,7 +62,7 @@ module.exports = class LevelModel {
       this.usePlayer = true;
     }
     if (this.usePlayer) {
-      this.player = new Player(this.controller, "Player", x, y, this.initialLevelData.playerName || "Steve", !this.actionPlane[this.yToIndex(y) + x].getIsEmptyOrEntity(), levelData.playerStartDirection);
+      this.player = new Player(this.controller, "Player", x, y, this.initialLevelData.playerName || "Steve", !this.actionPlane._data[this.yToIndex(y) + x].getIsEmptyOrEntity(), levelData.playerStartDirection);
       this.controller.levelEntity.pushEntity(this.player);
       this.controller.player = this.player;
     }
@@ -252,7 +252,7 @@ module.exports = class LevelModel {
       i;
 
     for (i = 0; i < this.planeArea(); ++i) {
-      if (blockType === this.actionPlane[i].blockType) {
+      if (blockType === this.actionPlane._data[i].blockType) {
         ++count;
       }
     }
@@ -279,14 +279,14 @@ module.exports = class LevelModel {
       // "" on the solution map means we dont care what's at that spot
       if (solutionItemType !== "") {
         if (solutionItemType === "empty") {
-          if (!this.actionPlane[i].isEmpty) {
+          if (!this.actionPlane._data[i].isEmpty) {
             return false;
           }
         } else if (solutionItemType === "any") {
-          if (this.actionPlane[i].isEmpty) {
+          if (this.actionPlane._data[i].isEmpty) {
             return false;
           }
-        } else if (this.actionPlane[i].blockType !== solutionItemType) {
+        } else if (this.actionPlane._data[i].blockType !== solutionItemType) {
           return false;
         }
       }
@@ -299,7 +299,7 @@ module.exports = class LevelModel {
     for (var x = 0; x < this.planeWidth; ++x) {
       for (var y = 0; y < this.planeHeight; ++y) {
         var index = this.coordinatesToIndex([x, y]);
-        var block = this.actionPlane[index];
+        var block = this.actionPlane._data[index];
         if (block.blockType === "tnt") {
           tnt.push([x, y]);
         }
@@ -313,9 +313,9 @@ module.exports = class LevelModel {
     for (var x = 0; x < this.planeWidth; ++x) {
       for (var y = 0; y < this.planeHeight; ++y) {
         var index = this.coordinatesToIndex([x, y]);
-        var block = this.actionPlane[index];
+        var block = this.actionPlane._data[index];
         if (block.blockType.substring(0, 7) === "railsUn") {
-          unpoweredRails.push([x, y], "railsPowered" + this.actionPlane[index].blockType.substring(14));
+          unpoweredRails.push([x, y], "railsPowered" + this.actionPlane._data[index].blockType.substring(14));
         }
       }
     }
@@ -482,7 +482,7 @@ module.exports = class LevelModel {
     posLeft = [0, position[1] - 1, position[2]];
     posRight[0] = this.yToIndex(posRight[2]) + posRight[1];
 
-    checkActionBlock = this.actionPlane[index];
+    checkActionBlock = this.actionPlane._data[index];
     for (var i = 0; i < array.length; ++i) {
       if (array[i][0] === index) {
         checkIndex = -1;
@@ -528,7 +528,7 @@ module.exports = class LevelModel {
   getAllBorderingPositionNotOfType(position, blockType) {
     var surroundingBlocks = this.getAllBorderingPosition(position, null);
     for (var b = 1; b < surroundingBlocks.length; ++b) {
-      if (surroundingBlocks[b][0] && this.actionPlane[this.coordinatesToIndex(surroundingBlocks[b][1])].blockType === blockType) {
+      if (surroundingBlocks[b][0] && this.actionPlane._data[this.coordinatesToIndex(surroundingBlocks[b][1])].blockType === blockType) {
         surroundingBlocks[b][0] = false;
       }
     }
@@ -682,7 +682,7 @@ module.exports = class LevelModel {
     }
     let plane = this.getPlaneToPlaceOn(this.getMoveForwardPosition());
     if (plane === this.groundPlane) {
-      if (blockType === "redstoneWire" || blockType.substring(0,5) === "rails" && this.groundPlane[this.groundPlane.coordinatesToIndex(this.getMoveForwardPosition())]) {
+      if (blockType === "redstoneWire" || blockType.substring(0,5) === "rails" && this.groundPlane._data[this.groundPlane.coordinatesToIndex(this.getMoveForwardPosition())]) {
         return false;
       }
     }
@@ -989,7 +989,7 @@ module.exports = class LevelModel {
     for (var y = 0; y < this.planeHeight; ++y) {
       for (var x = 0; x < this.planeWidth; ++x) {
         var index = this.coordinatesToIndex([x, y]);
-        if (!this.actionPlane[index].isEmpty && this.actionPlane[index].isEmissive || this.groundPlane[index].isEmissive && this.actionPlane[index].isEmpty) {
+        if (!this.actionPlane._data[index].isEmpty && this.actionPlane._data[index].isEmissive || this.groundPlane._data[index].isEmissive && this.actionPlane._data[index].isEmpty) {
           emissives.push([x, y]);
         }
       }
@@ -1133,7 +1133,7 @@ module.exports = class LevelModel {
 
       hasRight = false;
 
-      if (this.actionPlane[index].isEmpty || this.actionPlane[index].isTransparent) {
+      if (this.actionPlane._data[index].isEmpty || this.actionPlane._data[index].isTransparent) {
         if (y === 0) {
           this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_Bottom' });
         }
@@ -1150,12 +1150,12 @@ module.exports = class LevelModel {
           this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_Left' });
         }
 
-        if (x < this.planeWidth - 1 && !this.actionPlane[this.yToIndex(y) + x + 1].getIsEmptyOrEntity()) {
+        if (x < this.planeWidth - 1 && !this.actionPlane._data[this.yToIndex(y) + x + 1].getIsEmptyOrEntity()) {
           // needs a left side AO shadow
           this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_Left' });
         }
 
-        if (x > 0 && !this.actionPlane[this.yToIndex(y) + x - 1].getIsEmptyOrEntity()) {
+        if (x > 0 && !this.actionPlane._data[this.yToIndex(y) + x - 1].getIsEmptyOrEntity()) {
           // needs a right side AO shadow
           this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_Right' });
           this.shadingPlane.push({
@@ -1164,7 +1164,7 @@ module.exports = class LevelModel {
             type: 'Shadow_Parts_Fade_base.png'
           });
 
-          if (y > 0 && x > 0 && this.actionPlane[this.yToIndex(y - 1) + x - 1].getIsEmptyOrEntity()) {
+          if (y > 0 && x > 0 && this.actionPlane._data[this.yToIndex(y - 1) + x - 1].getIsEmptyOrEntity()) {
             this.shadingPlane.push({
               x: x,
               y: y,
@@ -1175,30 +1175,30 @@ module.exports = class LevelModel {
           hasRight = true;
         }
 
-        if (y > 0 && !this.actionPlane[this.yToIndex(y - 1) + x].getIsEmptyOrEntity()) {
+        if (y > 0 && !this.actionPlane._data[this.yToIndex(y - 1) + x].getIsEmptyOrEntity()) {
           // needs a bottom side AO shadow
           this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_Bottom' });
         } else if (y > 0) {
-          if (x < this.planeWidth - 1 && !this.actionPlane[this.yToIndex(y - 1) + x + 1].getIsEmptyOrEntity() &&
-            this.actionPlane[this.yToIndex(y) + x + 1].getIsEmptyOrEntity()) {
+          if (x < this.planeWidth - 1 && !this.actionPlane._data[this.yToIndex(y - 1) + x + 1].getIsEmptyOrEntity() &&
+            this.actionPlane._data[this.yToIndex(y) + x + 1].getIsEmptyOrEntity()) {
             // needs a bottom left side AO shadow
             this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_BottomLeft' });
           }
 
-          if (!hasRight && x > 0 && !this.actionPlane[this.yToIndex(y - 1) + x - 1].getIsEmptyOrEntity()) {
+          if (!hasRight && x > 0 && !this.actionPlane._data[this.yToIndex(y - 1) + x - 1].getIsEmptyOrEntity()) {
             // needs a bottom right side AO shadow
             this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_BottomRight' });
           }
         }
 
         if (y < this.planeHeight - 1) {
-          if (x < this.planeWidth - 1 && !this.actionPlane[this.yToIndex(y + 1) + x + 1].getIsEmptyOrEntity() &&
-            this.actionPlane[this.yToIndex(y) + x + 1].getIsEmptyOrEntity()) {
+          if (x < this.planeWidth - 1 && !this.actionPlane._data[this.yToIndex(y + 1) + x + 1].getIsEmptyOrEntity() &&
+            this.actionPlane._data[this.yToIndex(y) + x + 1].getIsEmptyOrEntity()) {
             // needs a bottom left side AO shadow
             this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_TopLeft' });
           }
 
-          if (!hasRight && x > 0 && !this.actionPlane[this.yToIndex(y + 1) + x - 1].getIsEmptyOrEntity()) {
+          if (!hasRight && x > 0 && !this.actionPlane._data[this.yToIndex(y + 1) + x - 1].getIsEmptyOrEntity()) {
             // needs a bottom right side AO shadow
             this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_TopRight' });
           }

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -38,7 +38,7 @@ const PoweredRailConnectionPriority = [
 
 module.exports = class LevelPlane {
   constructor(planeData, width, height, isActionPlane = false, LevelModel = null) {
-    this.data = [];
+    this._data = [];
     this.width = width;
     this.height = height;
     this.levelModel = LevelModel;
@@ -49,7 +49,7 @@ module.exports = class LevelPlane {
       let block = new LevelBlock(planeData[index]);
       // TODO(bjordan): put this truth in constructor like other attrs
       block.isWalkable = block.isWalkable || !isActionPlane;
-      this.data.push(block);
+      this._data.push(block);
     }
   }
 
@@ -85,7 +85,7 @@ module.exports = class LevelPlane {
     const target = [x + offsetX, y + offsetY];
 
     if (this.inBounds(target)) {
-      return this.data[this.coordinatesToIndex(target)];
+      return this._data[this.coordinatesToIndex(target)];
     }
   }
 
@@ -94,7 +94,7 @@ module.exports = class LevelPlane {
   * Important note: This is the cornerstone of block placing/destroying.
   */
   setBlockAt(position, block, offsetX = 0, offsetY = 0) {
-    this.data[this.coordinatesToIndex(position)] = block;
+    this._data[this.coordinatesToIndex(position)] = block;
     let offset = [offsetX,offsetY];
 
     let positionInQuestion = [0,0];
@@ -245,15 +245,15 @@ module.exports = class LevelPlane {
   getRedstone() {
     this.redstoneList = [];
     this.redstoneListON = [];
-    for (let i = 0; i < this.length; ++i) {
-      if (this.data[i].isRedstone) {
-        this.data[i].isPowered = false;
+    for (let i = 0; i < this._data.length; ++i) {
+      if (this._data[i].isRedstone) {
+        this._data[i].isPowered = false;
         let position = this.indexToCoordinates(i);
         this.redstoneList.push(position);
       }
     }
-    for (let i = 0; i < this.length; ++i) {
-      if (this.data[i].isRedstoneBattery) {
+    for (let i = 0; i < this._data.length; ++i) {
+      if (this._data[i].isRedstoneBattery) {
         let position = this.indexToCoordinates(i);
         this.redstonePropagation(position);
       }
@@ -277,16 +277,16 @@ module.exports = class LevelPlane {
   */
   findDoorToAnimate(positionInQuestion) {
     let notOffendingIndex = this.coordinatesToIndex(positionInQuestion);
-    for (let i = 0; i < this.length; ++i) {
-      if (this.data[i].blockType === "doorIron" && notOffendingIndex !== i) {
-        this.data[i].isPowered = this.powerCheck(this.indexToCoordinates(i));
-        if (this.data[i].isPowered && !this.data[i].isOpen) {
-          this.data[i].isOpen = true;
+    for (let i = 0; i < this._data.length; ++i) {
+      if (this._data[i].blockType === "doorIron" && notOffendingIndex !== i) {
+        this._data[i].isPowered = this.powerCheck(this.indexToCoordinates(i));
+        if (this._data[i].isPowered && !this._data[i].isOpen) {
+          this._data[i].isOpen = true;
           if (this.levelModel) {
             this.levelModel.controller.levelView.animateDoor(i, true);
           }
-        } else if (!this.data[i].isPowered && this.data[i].isOpen) {
-          this.data[i].isOpen = false;
+        } else if (!this._data[i].isPowered && this._data[i].isOpen) {
+          this._data[i].isOpen = false;
           if (this.levelModel) {
             this.levelModel.controller.levelView.animateDoor(i, false);
           }
@@ -313,12 +313,12 @@ module.exports = class LevelPlane {
   * propagates power to the surrounding indices.
   */
   redstonePropagation(position) {
-    let block = this.data[this.coordinatesToIndex(position)];
+    let block = this._data[this.coordinatesToIndex(position)];
     if (block.isRedstone) {
       let indexToRemove = this.findPositionInArray(position, this.redstoneList);
       this.redstoneList.splice(indexToRemove,1);
       this.redstoneListON.push(position);
-      this.data[this.coordinatesToIndex(position)].isPowered = true;
+      this._data[this.coordinatesToIndex(position)].isPowered = true;
     }
 
     this.getOrthogonalPositions(position).forEach(orthogonalPosition => {
@@ -331,7 +331,7 @@ module.exports = class LevelPlane {
   * the propagation call to surrounding indices.
   */
   blockPropagation(position) {
-    let adjacentBlock = this.data[position[1] * this.width + position[0]];
+    let adjacentBlock = this._data[position[1] * this.width + position[0]];
     if (this.inBounds(position) &&
       adjacentBlock.isPowered === false &&
       adjacentBlock.isRedstone) {
@@ -345,7 +345,7 @@ module.exports = class LevelPlane {
   */
   powerCheck(position) {
     return this.getOrthogonalPositions(position).some(orthogonalPosition => {
-      const block = this.data[this.coordinatesToIndex(orthogonalPosition)];
+      const block = this._data[this.coordinatesToIndex(orthogonalPosition)];
       if (block) {
         return (block.isRedstone && block.isPowered) || block.isRedstoneBattery;
       }

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -36,10 +36,9 @@ const PoweredRailConnectionPriority = [
   [East, West], [East, West], [East, West], [East, West],
 ];
 
-module.exports = class LevelPlane extends Array {
+module.exports = class LevelPlane {
   constructor(planeData, width, height, isActionPlane = false, LevelModel = null) {
-    super();
-
+    this.data = [];
     this.width = width;
     this.height = height;
     this.levelModel = LevelModel;
@@ -50,7 +49,7 @@ module.exports = class LevelPlane extends Array {
       let block = new LevelBlock(planeData[index]);
       // TODO(bjordan): put this truth in constructor like other attrs
       block.isWalkable = block.isWalkable || !isActionPlane;
-      this.push(block);
+      this.data.push(block);
     }
   }
 
@@ -86,7 +85,7 @@ module.exports = class LevelPlane extends Array {
     const target = [x + offsetX, y + offsetY];
 
     if (this.inBounds(target)) {
-      return this[this.coordinatesToIndex(target)];
+      return this.data[this.coordinatesToIndex(target)];
     }
   }
 
@@ -95,7 +94,7 @@ module.exports = class LevelPlane extends Array {
   * Important note: This is the cornerstone of block placing/destroying.
   */
   setBlockAt(position, block, offsetX = 0, offsetY = 0) {
-    this[this.coordinatesToIndex(position)] = block;
+    this.data[this.coordinatesToIndex(position)] = block;
     let offset = [offsetX,offsetY];
 
     let positionInQuestion = [0,0];
@@ -247,14 +246,14 @@ module.exports = class LevelPlane extends Array {
     this.redstoneList = [];
     this.redstoneListON = [];
     for (let i = 0; i < this.length; ++i) {
-      if (this[i].isRedstone) {
-        this[i].isPowered = false;
+      if (this.data[i].isRedstone) {
+        this.data[i].isPowered = false;
         let position = this.indexToCoordinates(i);
         this.redstoneList.push(position);
       }
     }
     for (let i = 0; i < this.length; ++i) {
-      if (this[i].isRedstoneBattery) {
+      if (this.data[i].isRedstoneBattery) {
         let position = this.indexToCoordinates(i);
         this.redstonePropagation(position);
       }
@@ -279,15 +278,15 @@ module.exports = class LevelPlane extends Array {
   findDoorToAnimate(positionInQuestion) {
     let notOffendingIndex = this.coordinatesToIndex(positionInQuestion);
     for (let i = 0; i < this.length; ++i) {
-      if (this[i].blockType === "doorIron" && notOffendingIndex !== i) {
-        this[i].isPowered = this.powerCheck(this.indexToCoordinates(i));
-        if (this[i].isPowered && !this[i].isOpen) {
-          this[i].isOpen = true;
+      if (this.data[i].blockType === "doorIron" && notOffendingIndex !== i) {
+        this.data[i].isPowered = this.powerCheck(this.indexToCoordinates(i));
+        if (this.data[i].isPowered && !this.data[i].isOpen) {
+          this.data[i].isOpen = true;
           if (this.levelModel) {
             this.levelModel.controller.levelView.animateDoor(i, true);
           }
-        } else if (!this[i].isPowered && this[i].isOpen) {
-          this[i].isOpen = false;
+        } else if (!this.data[i].isPowered && this.data[i].isOpen) {
+          this.data[i].isOpen = false;
           if (this.levelModel) {
             this.levelModel.controller.levelView.animateDoor(i, false);
           }
@@ -314,12 +313,12 @@ module.exports = class LevelPlane extends Array {
   * propagates power to the surrounding indices.
   */
   redstonePropagation(position) {
-    let block = this[this.coordinatesToIndex(position)];
+    let block = this.data[this.coordinatesToIndex(position)];
     if (block.isRedstone) {
       let indexToRemove = this.findPositionInArray(position, this.redstoneList);
       this.redstoneList.splice(indexToRemove,1);
       this.redstoneListON.push(position);
-      this[this.coordinatesToIndex(position)].isPowered = true;
+      this.data[this.coordinatesToIndex(position)].isPowered = true;
     }
 
     this.getOrthogonalPositions(position).forEach(orthogonalPosition => {
@@ -332,7 +331,7 @@ module.exports = class LevelPlane extends Array {
   * the propagation call to surrounding indices.
   */
   blockPropagation(position) {
-    let adjacentBlock = this[position[1] * this.width + position[0]];
+    let adjacentBlock = this.data[position[1] * this.width + position[0]];
     if (this.inBounds(position) &&
       adjacentBlock.isPowered === false &&
       adjacentBlock.isRedstone) {
@@ -346,7 +345,7 @@ module.exports = class LevelPlane extends Array {
   */
   powerCheck(position) {
     return this.getOrthogonalPositions(position).some(orthogonalPosition => {
-      const block = this[this.coordinatesToIndex(orthogonalPosition)];
+      const block = this.data[this.coordinatesToIndex(orthogonalPosition)];
       if (block) {
         return (block.isRedstone && block.isPowered) || block.isRedstoneBattery;
       }

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -618,7 +618,7 @@ module.exports = class LevelView {
       for (var i = 0; i < createFloor.length; ++i) {
         xCoord = createFloor[i][1];
         yCoord = createFloor[i][2];
-        /*this.groundPlane[this.coordinatesToIndex([xCoord,yCoord])].kill();*/
+        /*this.groundPlane._data[this.coordinatesToIndex([xCoord,yCoord])].kill();*/
         sprite = this.createBlock(this.groundPlane, xCoord, yCoord, "wool_orange");
         sprite.sortOrder = this.yToIndex(yCoord);
       }
@@ -1138,16 +1138,16 @@ module.exports = class LevelView {
         let blockIndex = (this.yToIndex(y)) + x;
         sprite = null;
 
-        if (!levelData.groundDecorationPlane[blockIndex].isEmpty) {
-          sprite = this.createBlock(this.actionPlane, x, y, levelData.groundDecorationPlane[blockIndex].blockType);
+        if (!levelData.groundDecorationPlane._data[blockIndex].isEmpty) {
+          sprite = this.createBlock(this.actionPlane, x, y, levelData.groundDecorationPlane._data[blockIndex].blockType);
           if (sprite) {
             sprite.sortOrder = this.yToIndex(y);
           }
         }
 
         sprite = null;
-        if (!levelData.actionPlane[blockIndex].isEmpty) {
-          blockType = levelData.actionPlane[blockIndex].blockType;
+        if (!levelData.actionPlane._data[blockIndex].isEmpty) {
+          blockType = levelData.actionPlane._data[blockIndex].blockType;
           sprite = this.createBlock(this.actionPlane, x, y, blockType);
           if (sprite !== null) {
             sprite.sortOrder = this.yToIndex(y);
@@ -1161,8 +1161,8 @@ module.exports = class LevelView {
     for (y = 0; y < this.controller.levelModel.planeHeight; ++y) {
       for (x = 0; x < this.controller.levelModel.planeWidth; ++x) {
         let blockIndex = (this.yToIndex(y)) + x;
-        if (!levelData.fluffPlane[blockIndex].isEmpty) {
-          sprite = this.createBlock(this.fluffPlane, x, y, levelData.fluffPlane[blockIndex].blockType);
+        if (!levelData.fluffPlane._data[blockIndex].isEmpty) {
+          sprite = this.createBlock(this.fluffPlane, x, y, levelData.fluffPlane._data[blockIndex].blockType);
         }
       }
     }
@@ -1173,7 +1173,7 @@ module.exports = class LevelView {
     for (var y = 0; y < this.controller.levelModel.planeHeight; ++y) {
       for (var x = 0; x < this.controller.levelModel.planeWidth; ++x) {
         let blockIndex = (this.yToIndex(y)) + x;
-        var sprite = this.createBlock(this.groundPlane, x, y, this.controller.levelModel.groundPlane[blockIndex].blockType);
+        var sprite = this.createBlock(this.groundPlane, x, y, this.controller.levelModel.groundPlane._data[blockIndex].blockType);
         if (sprite) {
           sprite.sortOrder = this.yToIndex(y);
         }
@@ -1900,7 +1900,7 @@ module.exports = class LevelView {
     this.controller.audioPlayer.play("doorOpen");
     // If it's not walable, then open otherwise, close.
     this.playDoorAnimation(this.controller.levelModel.actionPlane.indexToCoordinates(index), open, () => {
-      this.controller.levelModel.actionPlane[index].isWalkable = !this.controller.levelModel.actionPlane[index].isWalkable;
+      this.controller.levelModel.actionPlane._data[index].isWalkable = !this.controller.levelModel.actionPlane._data[index].isWalkable;
       this.playIdleAnimation(player.position, player.facing, player.isOnBlock);
       this.setSelectionIndicatorPosition(player.position[0], player.position[1]);
     });

--- a/test/unit/LevelPlaneTest.js
+++ b/test/unit/LevelPlaneTest.js
@@ -75,13 +75,8 @@ test('redstone wires', t => {
     'Horizontal','Cross',     'TUp',       'Horizontal',null,        'Vertical',
     null,        'Vertical',  null,        null,        'Horizontal','UpLeft',
   ].map(wire => wire === null ? '' : `redstoneWire${wire}`);
-  expected.width = undefined;
-  expected.height = undefined;
-  expected.levelModel = null;
-  expected.redstoneList = [];
-  expected.redstoneListON = [];
 
-  t.deepEqual(plane.map(block => block.blockType), expected);
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
 
   // Destroy a few wires.
   plane.setBlockAt([2, 1], new LevelBlock(''));
@@ -95,13 +90,8 @@ test('redstone wires', t => {
     null,        'TRight',    'Horizontal','Horizontal',null,         '',
     null,        'Vertical',  null,        null,        '',           null,
   ].map(wire => wire === null ? '' : `redstoneWire${wire}`);
-  expected.width = undefined;
-  expected.height = undefined;
-  expected.levelModel = null;
-  expected.redstoneList = [];
-  expected.redstoneListON = [];
 
-  t.deepEqual(plane.map(block => block.blockType), expected);
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
 
   t.end();
 });
@@ -140,13 +130,8 @@ test('rail connections: T-junctions', t => {
   ].map(rail => {
     return rail.replace('N', 'North').replace('S', 'South').replace('E', 'East').replace('W', 'West');
   });
-  expected.width = undefined;
-  expected.height = undefined;
-  expected.levelModel = null;
-  expected.redstoneList = [];
-  expected.redstoneListON = [];
 
-  t.deepEqual(plane.map(block => block.blockType), expected);
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
 
   t.end();
 });
@@ -185,13 +170,8 @@ test('rail connections: unpowered T-junctions', t => {
   ].map(rail => {
     return rail.replace('U', 'Unpowered').replace('N', 'North').replace('S', 'South').replace('E', 'East').replace('W', 'West');
   });
-  expected.width = undefined;
-  expected.height = undefined;
-  expected.levelModel = null;
-  expected.redstoneList = [];
-  expected.redstoneListON = [];
 
-  t.deepEqual(plane.map(block => block.blockType), expected);
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
 
   t.end();
 });
@@ -214,13 +194,8 @@ test('rail connections: 4x4 loop', t => {
     'railsSouthEast', 'railsSouthWest',
     'railsNorthEast', 'railsNorthWest',
   ];
-  expected.width = undefined;
-  expected.height = undefined;
-  expected.levelModel = null;
-  expected.redstoneList = [];
-  expected.redstoneListON = [];
 
-  t.deepEqual(plane.map(block => block.blockType), expected);
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
 
   t.end();
 });
@@ -253,13 +228,8 @@ test('rail connections: longer track', t => {
     '',               'railsNorthSouth','railsNorthEast', 'railsSouthWest',
     '',               'railsNorthEast', 'railsEastWest',  'railsNorthWest',
   ];
-  expected.width = undefined;
-  expected.height = undefined;
-  expected.levelModel = null;
-  expected.redstoneList = [];
-  expected.redstoneListON = [];
 
-  t.deepEqual(plane.map(block => block.blockType), expected);
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
 
   t.end();
 });
@@ -287,13 +257,8 @@ test('rail connections: destroy block', t => {
     '',               'railsSouthWest', '',
     '',               'railsNorthSouth','',
   ];
-  expected.width = undefined;
-  expected.height = undefined;
-  expected.levelModel = null;
-  expected.redstoneList = [];
-  expected.redstoneListON = [];
 
-  t.deepEqual(plane.map(block => block.blockType), expected);
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
 
   t.end();
 });
@@ -323,13 +288,7 @@ test('redstone charge: place block', t => {
     'redstoneWire',      '',         'redstoneWireVerticalOn',
   ];
 
-  expected.width = undefined;
-  expected.height = undefined;
-  expected.levelModel = null;
-  expected.redstoneList = [];
-  expected.redstoneListON = [];
-
-  t.deepEqual(plane.map(block => block.blockType), expected);
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
 
   t.end();
 });
@@ -356,13 +315,7 @@ test('redstone charge: destroy block', t => {
     'redstoneWire',      '',         'redstoneWireVertical',
   ];
 
-  expected.width = undefined;
-  expected.height = undefined;
-  expected.levelModel = null;
-  expected.redstoneList = [];
-  expected.redstoneListON = [];
-
-  t.deepEqual(plane.map(block => block.blockType), expected);
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
 
   t.end();
 });
@@ -389,13 +342,7 @@ test('torch charge: destroy block', t => {
     'redstoneWire',      '',         'redstoneWireVertical',
   ];
 
-  expected.width = undefined;
-  expected.height = undefined;
-  expected.levelModel = null;
-  expected.redstoneList = [];
-  expected.redstoneListON = [];
-
-  t.deepEqual(plane.map(block => block.blockType), expected);
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
 
   t.end();
 });
@@ -423,13 +370,7 @@ test('torch charge: place block', t => {
     '',            'railsRedstoneTorch','redstoneWireUpLeftOn',
   ];
 
-  expected.width = undefined;
-  expected.height = undefined;
-  expected.levelModel = null;
-  expected.redstoneList = [];
-  expected.redstoneListON = [];
-
-  t.deepEqual(plane.map(block => block.blockType), expected);
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
 
   t.end();
 });


### PR DESCRIPTION
This was causing problems during the ES5 transpile.  More details here: http://perfectionkills.com/how-ecmascript-5-still-does-not-allow-to-subclass-an-array/

For now I updated everything as-is to avoid introducing new issues.  There are a bunch of places we're reaching directly in to `actionPlane._data`.  We should clean up some of those to use `getBlockAt` in a future PR!