### PR TITLE
Reset should move the camera to start position (when not following)

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -224,6 +224,8 @@ module.exports = class LevelView {
       this.game.camera.follow(this.player.sprite);
       this.game.world.scale.x = 1;
       this.game.world.scale.y = 1;
+    } else {
+      this.game.world.setBounds(0, 0, 400, 400);
     }
   }
 


### PR DESCRIPTION
Fixes running Adventurer 13 a second time, after the cut scene animation has finished.