### PR TITLE
add support for miniblocks in level specification

### DIFF
--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -146,8 +146,11 @@ module.exports = class LevelBlock {
     }
   }
 
+  /**
+   * @return {boolean}
+   */
   getIsMiniblock() {
-    return this.blockType.endsWith("Miniblock")
+    return LevelBlock.isMiniblock(this.blockType);
   }
 
   getIsTree() {
@@ -164,5 +167,95 @@ module.exports = class LevelBlock {
 
   getIsEmptyOrEntity() {
     return this.isEmpty || this.isEntity;
+  }
+
+  /**
+   * Does the given block type represent a miniblock?
+   *
+   * @param {String} blockType
+   * @return {boolean}
+   */
+  static isMiniblock(blockType) {
+    return blockType.endsWith("Miniblock")
+  }
+
+  /**
+   * For any given block type, get the appropriate mini block frame (as defined
+   * in LevelView.miniblocks) if it exists.
+   *
+   * For miniblock block types, this should be the miniblock itself, so this
+   * means simply removing the "Miniblock" identifier, so a "diamondMiniblock"
+   * block will produce a "diamond" frame.
+   *
+   * For regular block types, this should be the miniblock produced when
+   * destroying the block type, so a "oreDiamond" block will produce a "diamond"
+   * frame
+   *
+   * @param {String} blockType
+   * @return {String} frame identifier
+   */
+  static getMiniblockFrame(blockType) {
+    // We don't have rails miniblock assets yet.
+    if (blockType.startsWith("rails")) {
+      return;
+    }
+
+    // We use the same miniblock for -all- restoneWire
+    if (blockType.substring(0,12) === "redstoneWire") {
+      return "redstoneDust";
+    }
+
+    // Miniblock block types are suffixed with the string "Miniblock"
+    if (LevelBlock.isMiniblock(blockType)) {
+      return blockType.replace("Miniblock", "");
+    }
+
+    // For everything else, simply map the block type to the desired miniblock
+    let frame = blockType;
+
+    switch (frame) {
+      case "treeAcacia":
+      case "treeBirch":
+      case "treeJungle":
+      case "treeOak":
+      case "treeSpruce":
+        frame = "log" + frame.substring(4);
+        break;
+      case "stone":
+        frame = "cobblestone";
+        break;
+      case "oreCoal":
+        frame = "coal";
+        break;
+      case "oreDiamond":
+        frame = "diamond";
+        break;
+      case "oreIron":
+        frame = "ingotIron";
+        break;
+      case "oreLapis":
+        frame = "lapisLazuli";
+        break;
+      case "oreGold":
+        frame = "ingotGold";
+        break;
+      case "oreEmerald":
+        frame = "emerald";
+        break;
+      case "oreRedstone":
+        frame = "redstoneDust";
+        break;
+      case "grass":
+        frame = "dirt";
+        break;
+      case "wool_orange":
+        frame = "wool";
+        break;
+      case "tnt":
+        frame = "gunPowder";
+        break;
+    }
+
+    return frame;
   }
 };

--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -176,7 +176,7 @@ module.exports = class LevelBlock {
    * @return {boolean}
    */
   static isMiniblock(blockType) {
-    return blockType.endsWith("Miniblock")
+    return blockType.endsWith("Miniblock");
   }
 
   /**

--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -25,6 +25,15 @@ module.exports = class LevelBlock {
       this.isUsable = false;
     }
 
+    if (blockType.endsWith("Miniblock")) {
+      this.isEntity = true;
+      this.isWalkable = true;
+      this.isDestroyable = false;
+      this.isPlacable = true;
+      this.isUsable = false;
+      this.isTransparent = true;
+    }
+
     if (blockType.match('torch')) {
       this.isWalkable = true;
       this.isPlacable = true;

--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -25,7 +25,7 @@ module.exports = class LevelBlock {
       this.isUsable = false;
     }
 
-    if (blockType.endsWith("Miniblock")) {
+    if (this.getIsMiniblock()) {
       this.isEntity = true;
       this.isWalkable = true;
       this.isDestroyable = false;
@@ -144,6 +144,10 @@ module.exports = class LevelBlock {
         this.isEntity = true;
       }
     }
+  }
+
+  getIsMiniblock() {
+    return this.blockType.endsWith("Miniblock")
   }
 
   getIsTree() {

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1175,13 +1175,12 @@ module.exports = class LevelView {
         }
 
         sprite = null;
-        if (!levelData.actionPlane.getBlockAt(position).isEmpty) {
-          blockType = levelData.actionPlane.getBlockAt(position).blockType;
-
-          if (blockType.endsWith("Miniblock")) {
-            sprite = this.createMiniBlock(x, y, blockType.replace("Miniblock", ""));
+        const actionBlock = levelData.actionPlane.getBlockAt(position);
+        if (!actionBlock.isEmpty) {
+          if (actionBlock.getIsMiniblock()) {
+            sprite = this.createMiniBlock(x, y, actionBlock.blockType);
           } else {
-            sprite = this.createBlock(this.actionPlane, x, y, blockType);
+            sprite = this.createBlock(this.actionPlane, x, y, actionBlock.blockType);
           }
 
           if (sprite !== null) {

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1177,7 +1177,13 @@ module.exports = class LevelView {
         sprite = null;
         if (!levelData.actionPlane.getBlockAt(position).isEmpty) {
           blockType = levelData.actionPlane.getBlockAt(position).blockType;
-          sprite = this.createBlock(this.actionPlane, x, y, blockType);
+
+          if (blockType.endsWith("Miniblock")) {
+            sprite = this.createMiniBlock(x, y, blockType.replace("Miniblock", ""));
+          } else {
+            sprite = this.createBlock(this.actionPlane, x, y, blockType);
+          }
+
           if (sprite !== null) {
             sprite.sortOrder = this.yToIndex(y);
           }

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1,3 +1,4 @@
+const LevelBlock = require("./LevelBlock.js");
 const FacingDirection = require("./FacingDirection.js");
 
 module.exports = class LevelView {

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1142,8 +1142,7 @@ module.exports = class LevelView {
   resetPlanes(levelData) {
     var sprite,
       x,
-      y,
-      blockType;
+      y;
 
     this.groundPlane.removeAll(true);
     this.actionPlane.removeAll(true);
@@ -1587,7 +1586,7 @@ module.exports = class LevelView {
    */
   createMiniBlock(x, y, blockType) {
     let sprite = null,
-        frameList;
+      frameList;
 
     const frame = LevelBlock.getMiniblockFrame(blockType);
     const atlas = "miniBlocks";

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1576,84 +1576,36 @@ module.exports = class LevelView {
     entity.sprite.animations.add('jumpDown' + direction, Phaser.Animation.generateFrameNames("Player_", offset + 55, offset + 60, "", 3), frameRate, true);
   }
 
+  /**
+   * Create a "miniblock" asset (representing a floating collectable) based on
+   * the given block at the given coordinates
+   *
+   * @param {Number} x
+   * @param {Number} y
+   * @param {String} blockType
+   */
   createMiniBlock(x, y, blockType) {
-    var frame = "",
-      sprite = null,
-      frameList;
+    let sprite = null,
+        frameList;
 
-    // We don't have rails miniblock assets yet.
-    if (blockType.startsWith("rails")) {
-      return;
-    }
-
-    // Need to make sure the switch case will capture the right miniBlock for -all- redstoneWire
-    if (blockType.substring(0,12) === "redstoneWire") {
-      blockType = "redstoneDust";
-    }
-
-    switch (blockType) {
-      case "treeAcacia":
-      case "treeBirch":
-      case "treeJungle":
-      case "treeOak":
-      case "treeSpruce":
-        frame = "log" + blockType.substring(4);
-        break;
-      case "stone":
-        frame = "cobblestone";
-        break;
-      case "oreCoal":
-        frame = "coal";
-        break;
-      case "oreDiamond":
-        frame = "diamond";
-        break;
-      case "oreIron":
-        frame = "ingotIron";
-        break;
-      case "oreLapis":
-        frame = "lapisLazuli";
-        break;
-      case "oreGold":
-        frame = "ingotGold";
-        break;
-      case "oreEmerald":
-        frame = "emerald";
-        break;
-      case "oreRedstone":
-        frame = "redstoneDust";
-        break;
-      case "grass":
-        frame = "dirt";
-        break;
-      case "wool_orange":
-        frame = "wool";
-        break;
-      case "tnt":
-        frame = "gunPowder";
-        break;
-      default:
-        frame = blockType;
-        break;
-    }
-
-    let atlas = "miniBlocks";
-    let framePrefix = this.miniBlocks[frame][0];
-    let frameStart = this.miniBlocks[frame][1];
-    let frameEnd = this.miniBlocks[frame][2];
-    let xOffset = -10 - 20 + Math.random() * 40;
-    let yOffset = 0 - 20 + Math.random() * 40;
+    const frame = LevelBlock.getMiniblockFrame(blockType);
+    const atlas = "miniBlocks";
+    const framePrefix = this.miniBlocks[frame][0];
+    const frameStart = this.miniBlocks[frame][1];
+    const frameEnd = this.miniBlocks[frame][2];
+    const xOffset = -10 - 20 + Math.random() * 40;
+    const yOffset = 0 - 20 + Math.random() * 40;
 
     frameList = Phaser.Animation.generateFrameNames(framePrefix, frameStart, frameEnd, ".png", 3);
     sprite = this.actionPlane.create(xOffset + 40 * x, yOffset + this.actionPlane.yOffset + 40 * y, atlas, "");
-    var anim = sprite.animations.add("animate", frameList, 10, false);
+    const anim = sprite.animations.add("animate", frameList, 10, false);
 
     if (this.controller.levelData.isEventLevel) {
-      var distanceBetween = function (position, position2) {
+      const distanceBetween = function (position, position2) {
         return Math.sqrt(Math.pow(position[0] - position2[0], 2) + Math.pow(position[1] - position2[1], 2));
       };
 
-      let collectiblePosition = this.controller.levelModel.spritePositionToIndex([xOffset, yOffset], [sprite.x, sprite.y]);
+      const collectiblePosition = this.controller.levelModel.spritePositionToIndex([xOffset, yOffset], [sprite.x, sprite.y]);
       anim.onComplete.add(() => {
         if (this.controller.levelModel.usePlayer) {
           if (distanceBetween(this.player.position, collectiblePosition) < 2) {

--- a/test/unit/LevelBlockTest.js
+++ b/test/unit/LevelBlockTest.js
@@ -1,0 +1,43 @@
+const test = require('tape');
+
+const LevelBlock = require('../../src/js/game/LevelMVC/LevelBlock');
+
+test('isMiniblock', t => {
+  const defaultBlock = new LevelBlock("");
+  t.equal(defaultBlock.getIsMiniblock(), false);
+
+  const miniBlock = new LevelBlock("diamondMiniblock");
+  t.equal(miniBlock.getIsMiniblock(), true);
+
+  t.end();
+});
+
+test('getMiniblockFrame', t => {
+  // All the various forms of redstone resolve to the same thing
+  [
+    'oreRedstone',
+    'redstoneDust',
+    'redstoneDustMiniblock',
+    'redstoneWire',
+    'redstoneWireHorizontal',
+    'redstoneWireOn',
+    'redstoneWireTUp',
+  ].forEach(blockType => {
+    t.equal(LevelBlock.getMiniblockFrame(blockType), "redstoneDust");
+  });
+
+  // Rails give us nothing
+  t.equal(LevelBlock.getMiniblockFrame("rails"), undefined);
+
+  // Generally, the in-world blocks, the miniblock-specific blocks, and the
+  // miniblock frame itself should all resolve to just the miniblock frame
+  [
+    "oreDiamond",
+    "diamondMiniblock",
+    "diamond"
+  ].forEach(blockType => {
+    t.equal(LevelBlock.getMiniblockFrame(blockType), "diamond");
+  });
+
+  t.end();
+});


### PR DESCRIPTION
Levelbuilders can now add miniblocks that appear at level initialization, and which will be collected by the player just like other collectables:

![diamond](https://user-images.githubusercontent.com/244100/30459720-40056e12-9967-11e7-9e92-f9af53fe72e2.gif)

Two things to note:

First, the default range for collectables is pretty large; the feature this functionality is desired for involves adding diamonds to levels to give the player an extra challenge, and it would probably be nice for that to have a more restrictive area. (but that's an issue for a separate PR)

Second, to enable this on levelbuilder, we simply need to add the appropriate strings to the set of block options for the level:

```
diff --git a/dashboard/app/models/levels/craft.rb b/dashboard/app/models/levels/craft.rb
index 6a551e026f..b8300b3cc5 100644
--- a/dashboard/app/models/levels/craft.rb
+++ b/dashboard/app/models/levels/craft.rb
@@ -221,6 +221,7 @@ class Craft < Blockly
     },
     action_plane: ALL_BLOCKS.merge(
       {
+        diamondMiniblock: true,
         creeper: true,
         sheep: true,
         cropWheat: true,
```