### PR TITLE
Add levelPlace._data access methods

### DIFF
--- a/src/js/game/Entities/BaseEntity.js
+++ b/src/js/game/Entities/BaseEntity.js
@@ -139,7 +139,7 @@ module.exports = class BaseEntity {
         var prevPosition = this.position;
         this.position = forwardPosition;
         // play sound effect
-        let groundType = levelModel.groundPlane.getBlock(levelModel.yToIndex(this.position[1]) + this.position[0]).blockType;
+        let groundType = levelModel.groundPlane.getBlockAt(this.position).blockType;
         // play move forward animation and play idle after that
         this.playMoveForwardAnimation(forwardPosition, this.facing, commandQueueItem, groundType, () => {
         });

--- a/src/js/game/Entities/BaseEntity.js
+++ b/src/js/game/Entities/BaseEntity.js
@@ -139,7 +139,7 @@ module.exports = class BaseEntity {
         var prevPosition = this.position;
         this.position = forwardPosition;
         // play sound effect
-        let groundType = levelModel.groundPlane._data[levelModel.yToIndex(this.position[1]) + this.position[0]].blockType;
+        let groundType = levelModel.groundPlane.getBlock(levelModel.yToIndex(this.position[1]) + this.position[0]).blockType;
         // play move forward animation and play idle after that
         this.playMoveForwardAnimation(forwardPosition, this.facing, commandQueueItem, groundType, () => {
         });

--- a/src/js/game/Entities/Player.js
+++ b/src/js/game/Entities/Player.js
@@ -65,9 +65,9 @@ module.exports = class Player extends BaseEntity {
 
     jumpOff = wasOnBlock && wasOnBlock !== player.isOnBlock;
     if (player.isOnBlock || jumpOff) {
-      groundType = levelModel.actionPlane._data[levelModel.yToIndex(player.position[1]) + player.position[0]].blockType;
+      groundType = levelModel.actionPlane.getBlock(levelModel.yToIndex(player.position[1]) + player.position[0]).blockType;
     } else {
-      groundType = levelModel.groundPlane._data[levelModel.yToIndex(player.position[1]) + player.position[0]].blockType;
+      groundType = levelModel.groundPlane.getBlock(levelModel.yToIndex(player.position[1]) + player.position[0]).blockType;
     }
 
     levelView.playMoveForwardAnimation(player, prevPosition, player.facing, jumpOff, player.isOnBlock, groundType, () => {

--- a/src/js/game/Entities/Player.js
+++ b/src/js/game/Entities/Player.js
@@ -65,9 +65,9 @@ module.exports = class Player extends BaseEntity {
 
     jumpOff = wasOnBlock && wasOnBlock !== player.isOnBlock;
     if (player.isOnBlock || jumpOff) {
-      groundType = levelModel.actionPlane.getBlock(levelModel.yToIndex(player.position[1]) + player.position[0]).blockType;
+      groundType = levelModel.actionPlane.getBlockAt(player.position).blockType;
     } else {
-      groundType = levelModel.groundPlane.getBlock(levelModel.yToIndex(player.position[1]) + player.position[0]).blockType;
+      groundType = levelModel.groundPlane.getBlockAt(player.position).blockType;
     }
 
     levelView.playMoveForwardAnimation(player, prevPosition, player.facing, jumpOff, player.isOnBlock, groundType, () => {

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1281,7 +1281,7 @@ class GameController {
     if (!this.levelModel.inBounds(position[0], position[1])) {
       return;
     }
-    let block = this.levelModel.actionPlane.getBlock(this.levelModel.yToIndex(position[1]) + position[0]);
+    let block = this.levelModel.actionPlane.getBlockAt(position);
 
     if (block !== null && block !== undefined) {
       let destroyPosition = position;
@@ -1349,7 +1349,7 @@ class GameController {
         this.levelModel.destroyBlock(blockIndex);
       }
 
-      if (blockType !== "cropWheat" || this.levelModel.groundPlane.getBlockAt((this.levelModel.player.position)).blockType === "farmlandWet") {
+      if (blockType !== "cropWheat" || this.levelModel.groundPlane.getBlockAt(this.levelModel.player.position).blockType === "farmlandWet") {
         this.levelModel.player.updateHidingBlock(this.levelModel.player.position);
         this.levelView.playPlaceBlockAnimation(this.levelModel.player.position, this.levelModel.player.facing, blockType, blockTypeAtPosition, () => {
           if (this.checkMinecartLevelEndAnimation() && blockType === "rail") {

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1160,8 +1160,8 @@ class GameController {
     let player = this.levelModel.player;
     let frontPosition = this.levelModel.getMoveForwardPosition(player);
     let frontEntity = this.levelEntity.getEntityAt(frontPosition);
-    const frontIndex = this.levelModel.yToIndex(frontPosition[1]) + frontPosition[0];
-    let frontBlock = this.levelModel.actionPlane.getBlock(frontIndex);
+    let frontBlock = this.levelModel.actionPlane.getBlockAt(frontPosition);
+
     const isFrontBlockDoor = frontBlock === undefined ? false : frontBlock.blockType === "door";
     if (frontEntity !== null) {
       // push use command to execute general use behavior of the entity before executing the event
@@ -1342,11 +1342,12 @@ class GameController {
   }
 
   placeBlock(commandQueueItem, blockType) {
-    let blockIndex = (this.levelModel.yToIndex(this.levelModel.player.position[1]) + this.levelModel.player.position[0]);
-    let blockTypeAtPosition = this.levelModel.actionPlane.getBlock(blockIndex).blockType;
+    const position = this.levelModel.player.position;
+    let blockTypeAtPosition = this.levelModel.actionPlane.getBlockAt(position).blockType;
+
     if (this.levelModel.canPlaceBlock()) {
       if (blockTypeAtPosition !== "") {
-        this.levelModel.destroyBlock(blockIndex);
+        this.levelModel.destroyBlock(position);
       }
 
       if (blockType !== "cropWheat" || this.levelModel.groundPlane.getBlockAt(this.levelModel.player.position).blockType === "farmlandWet") {

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1161,7 +1161,7 @@ class GameController {
     let frontPosition = this.levelModel.getMoveForwardPosition(player);
     let frontEntity = this.levelEntity.getEntityAt(frontPosition);
     const frontIndex = this.levelModel.yToIndex(frontPosition[1]) + frontPosition[0];
-    let frontBlock = this.levelModel.actionPlane._data[frontIndex];
+    let frontBlock = this.levelModel.actionPlane.getBlock(frontIndex);
     const isFrontBlockDoor = frontBlock === undefined ? false : frontBlock.blockType === "door";
     if (frontEntity !== null) {
       // push use command to execute general use behavior of the entity before executing the event
@@ -1281,7 +1281,7 @@ class GameController {
     if (!this.levelModel.inBounds(position[0], position[1])) {
       return;
     }
-    let block = this.levelModel.actionPlane._data[this.levelModel.yToIndex(position[1]) + position[0]];
+    let block = this.levelModel.actionPlane.getBlock(this.levelModel.yToIndex(position[1]) + position[0]);
 
     if (block !== null && block !== undefined) {
       let destroyPosition = position;
@@ -1343,7 +1343,7 @@ class GameController {
 
   placeBlock(commandQueueItem, blockType) {
     let blockIndex = (this.levelModel.yToIndex(this.levelModel.player.position[1]) + this.levelModel.player.position[0]);
-    let blockTypeAtPosition = this.levelModel.actionPlane._data[blockIndex].blockType;
+    let blockTypeAtPosition = this.levelModel.actionPlane.getBlock(blockIndex).blockType;
     if (this.levelModel.canPlaceBlock()) {
       if (blockTypeAtPosition !== "") {
         this.levelModel.destroyBlock(blockIndex);

--- a/src/js/game/LevelMVC/AStarPathFinding.js
+++ b/src/js/game/LevelMVC/AStarPathFinding.js
@@ -6,18 +6,15 @@ module.exports = class AStarPathFinding {
   }
 
   createGrid() {
-    let tempGrid = [];
-    for (let i = 0; i < this.levelModel.actionPlane.getBlockCount(); i++) {
-      let coordinates = this.levelModel.indexToXY(i);
-      // Push node objects.
-      tempGrid.push({
-        x: coordinates.x,
-        y: coordinates.y,
+    return this.levelModel.actionPlane.getAllPositions().map((position) => {
+      const [x, y] = position;
+      return {
+        x: x,
+        y: y,
         cost: 1,    // cost is 1 so that all blocks are treated the same but could do something with lava, water.
         f: 0, g: 0, h: 0, visited: false, closed: false, parent: null
-      });
-    }
-    return tempGrid;
+      };
+    });
   }
 
   reset() {

--- a/src/js/game/LevelMVC/AStarPathFinding.js
+++ b/src/js/game/LevelMVC/AStarPathFinding.js
@@ -7,7 +7,7 @@ module.exports = class AStarPathFinding {
 
   createGrid() {
     let tempGrid = [];
-    for (let i = 0; i < this.levelModel.actionPlane._data.length; i++) {
+    for (let i = 0; i < this.levelModel.actionPlane.getBlockCount(); i++) {
       let coordinates = this.levelModel.indexToXY(i);
       // Push node objects.
       tempGrid.push({
@@ -41,7 +41,7 @@ module.exports = class AStarPathFinding {
   getNode(position) {
     const index = this.levelModel.coordinatesToIndex(position);
     if (this.levelModel.inBounds(position[0], position[1]) &&   // is the node within bounds
-        this.levelModel.actionPlane._data[index].isEmpty &&           // is the node empty
+        this.levelModel.actionPlane.getBlock(index).isEmpty &&  // is the node empty
         !this.grid[index].closed) {                             // has the node already been processed.
       return this.grid[index];
     }

--- a/src/js/game/LevelMVC/AStarPathFinding.js
+++ b/src/js/game/LevelMVC/AStarPathFinding.js
@@ -40,9 +40,9 @@ module.exports = class AStarPathFinding {
 
   getNode(position) {
     const index = this.levelModel.coordinatesToIndex(position);
-    if (this.levelModel.inBounds(position[0], position[1]) &&   // is the node within bounds
-        this.levelModel.actionPlane.getBlock(index).isEmpty &&  // is the node empty
-        !this.grid[index].closed) {                             // has the node already been processed.
+    if (this.levelModel.inBounds(position[0], position[1]) &&        // is the node within bounds
+        this.levelModel.actionPlane.getBlockAt(position).isEmpty &&  // is the node empty
+        !this.grid[index].closed) {                                  // has the node already been processed.
       return this.grid[index];
     }
     return null;

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -39,20 +39,17 @@ module.exports = class LevelModel {
     this.shadingPlane = [];
     this.actionPlane = new LevelPlane(this.initialLevelData.actionPlane, this.planeWidth, this.planeHeight, this.controller, this, true);
 
-    for (let i = 0; i < this.actionPlane.getBlockCount(); ++i) {
-      if (this.actionPlane.getBlock(i).blockType === "railsRedstoneTorch") {
-        let position = this.actionPlane.indexToCoordinates(i);
+    this.actionPlane.getAllPositions().forEach((position) => {
+      if (this.actionPlane.getBlockAt(position).blockType === "railsRedstoneTorch") {
         this.actionPlane.redstonePropagation(position);
       }
-    }
-    for (let i = 0; i < this.actionPlane.getBlockCount(); ++i) {
-      if (this.actionPlane.getBlock(i).blockType.substring(0,12) === "redstoneWire") {
-        let y = Math.floor(i / this.planeHeight);
-        let x = i - (y * this.planeHeight);
-        let position = [x,y];
-        this.actionPlane.determineRedstoneSprite(position, i);
+    });
+
+    this.actionPlane.getAllPositions().forEach((position) => {
+      if (this.actionPlane.getBlockAt(position).blockType.substring(0,12) === "redstoneWire") {
+        this.actionPlane.determineRedstoneSprite(position);
       }
-    }
+    });
 
     this.fluffPlane = new LevelPlane(this.initialLevelData.fluffPlane, this.planeWidth, this.planeHeight);
     this.fowPlane = [];
@@ -260,15 +257,11 @@ module.exports = class LevelModel {
   }
 
   countOfTypeOnMap(blockType) {
-    var count = 0,
-      i;
+    const blocksOfType = this.actionPlane.getAllPositions().filter((position) => {
+      return this.actionPlane.getBlockAt(position).blockType === blockType;
+    });
 
-    for (i = 0; i < this.planeArea(); ++i) {
-      if (blockType === this.actionPlane.getBlock(i).blockType) {
-        ++count;
-      }
-    }
-    return count;
+    return blocksOfType.length;
   }
 
   isPlayerAt(position) {

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -66,7 +66,7 @@ module.exports = class LevelModel {
       this.usePlayer = true;
     }
     if (this.usePlayer) {
-      this.player = new Player(this.controller, "Player", x, y, this.initialLevelData.playerName || "Steve", !this.actionPlane.getBlock(this.yToIndex(y) + x).getIsEmptyOrEntity(), levelData.playerStartDirection);
+      this.player = new Player(this.controller, "Player", x, y, this.initialLevelData.playerName || "Steve", !this.actionPlane.getBlockAt([x, y]).getIsEmptyOrEntity(), levelData.playerStartDirection);
       this.controller.levelEntity.pushEntity(this.player);
       this.controller.player = this.player;
 
@@ -540,7 +540,7 @@ module.exports = class LevelModel {
   getAllBorderingPositionNotOfType(position, blockType) {
     var surroundingBlocks = this.getAllBorderingPosition(position, null);
     for (var b = 1; b < surroundingBlocks.length; ++b) {
-      if (surroundingBlocks[b][0] && this.actionPlane.getBlock(this.coordinatesToIndex(surroundingBlocks[b][1])).blockType === blockType) {
+      if (surroundingBlocks[b][0] && this.actionPlane.getBlockAt(surroundingBlocks[b][1]).blockType === blockType) {
         surroundingBlocks[b][0] = false;
       }
     }
@@ -673,7 +673,7 @@ module.exports = class LevelModel {
     }
     let plane = this.getPlaneToPlaceOn(this.getMoveForwardPosition(entity));
     if (plane === this.groundPlane) {
-      if (blockType === "redstoneWire" || blockType.substring(0,5) === "rails" && this.groundPlane.getBlock(this.groundPlane.coordinatesToIndex(this.getMoveForwardPosition()))) {
+      if (blockType === "redstoneWire" || blockType.substring(0,5) === "rails" && this.groundPlane.getBlockAt(this.getMoveForwardPosition())) {
         return false;
       }
     }

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -39,14 +39,14 @@ module.exports = class LevelModel {
     this.shadingPlane = [];
     this.actionPlane = new LevelPlane(this.initialLevelData.actionPlane, this.planeWidth, this.planeHeight, this.controller, this, true);
 
-    for (let i = 0; i < this.actionPlane._data.length; ++i) {
-      if (this.actionPlane._data[i].blockType === "railsRedstoneTorch") {
+    for (let i = 0; i < this.actionPlane.getBlockCount(); ++i) {
+      if (this.actionPlane.getBlock(i).blockType === "railsRedstoneTorch") {
         let position = this.actionPlane.indexToCoordinates(i);
         this.actionPlane.redstonePropagation(position);
       }
     }
-    for (let i = 0; i < this.actionPlane._data.length; ++i) {
-      if (this.actionPlane._data[i].blockType.substring(0,12) === "redstoneWire") {
+    for (let i = 0; i < this.actionPlane.getBlockCount(); ++i) {
+      if (this.actionPlane.getBlock(i).blockType.substring(0,12) === "redstoneWire") {
         let y = Math.floor(i / this.planeHeight);
         let x = i - (y * this.planeHeight);
         let position = [x,y];
@@ -66,7 +66,7 @@ module.exports = class LevelModel {
       this.usePlayer = true;
     }
     if (this.usePlayer) {
-      this.player = new Player(this.controller, "Player", x, y, this.initialLevelData.playerName || "Steve", !this.actionPlane._data[this.yToIndex(y) + x].getIsEmptyOrEntity(), levelData.playerStartDirection);
+      this.player = new Player(this.controller, "Player", x, y, this.initialLevelData.playerName || "Steve", !this.actionPlane.getBlock(this.yToIndex(y) + x).getIsEmptyOrEntity(), levelData.playerStartDirection);
       this.controller.levelEntity.pushEntity(this.player);
       this.controller.player = this.player;
 
@@ -264,7 +264,7 @@ module.exports = class LevelModel {
       i;
 
     for (i = 0; i < this.planeArea(); ++i) {
-      if (blockType === this.actionPlane._data[i].blockType) {
+      if (blockType === this.actionPlane.getBlock(i).blockType) {
         ++count;
       }
     }
@@ -291,14 +291,14 @@ module.exports = class LevelModel {
       // "" on the solution map means we dont care what's at that spot
       if (solutionItemType !== "") {
         if (solutionItemType === "empty") {
-          if (!this.actionPlane._data[i].isEmpty) {
+          if (!this.actionPlane.getBlock(i).isEmpty) {
             return false;
           }
         } else if (solutionItemType === "any") {
-          if (this.actionPlane._data[i].isEmpty) {
+          if (this.actionPlane.getBlock(i).isEmpty) {
             return false;
           }
-        } else if (this.actionPlane._data[i].blockType !== solutionItemType) {
+        } else if (this.actionPlane.getBlock(i).blockType !== solutionItemType) {
           return false;
         }
       }
@@ -311,7 +311,7 @@ module.exports = class LevelModel {
     for (var x = 0; x < this.planeWidth; ++x) {
       for (var y = 0; y < this.planeHeight; ++y) {
         var index = this.coordinatesToIndex([x, y]);
-        var block = this.actionPlane._data[index];
+        var block = this.actionPlane.getBlock(index);
         if (block.blockType === "tnt") {
           tnt.push([x, y]);
         }
@@ -325,9 +325,9 @@ module.exports = class LevelModel {
     for (var x = 0; x < this.planeWidth; ++x) {
       for (var y = 0; y < this.planeHeight; ++y) {
         var index = this.coordinatesToIndex([x, y]);
-        var block = this.actionPlane._data[index];
+        var block = this.actionPlane.getBlock(index);
         if (block.blockType.substring(0, 7) === "railsUn") {
-          unpoweredRails.push([x, y], "railsPowered" + this.actionPlane._data[index].blockType.substring(14));
+          unpoweredRails.push([x, y], "railsPowered" + this.actionPlane.getBlock(index).blockType.substring(14));
         }
       }
     }
@@ -494,7 +494,7 @@ module.exports = class LevelModel {
     posLeft = [0, position[1] - 1, position[2]];
     posRight[0] = this.yToIndex(posRight[2]) + posRight[1];
 
-    checkActionBlock = this.actionPlane._data[index];
+    checkActionBlock = this.actionPlane.getBlock(index);
     for (var i = 0; i < array.length; ++i) {
       if (array[i][0] === index) {
         checkIndex = -1;
@@ -540,7 +540,7 @@ module.exports = class LevelModel {
   getAllBorderingPositionNotOfType(position, blockType) {
     var surroundingBlocks = this.getAllBorderingPosition(position, null);
     for (var b = 1; b < surroundingBlocks.length; ++b) {
-      if (surroundingBlocks[b][0] && this.actionPlane._data[this.coordinatesToIndex(surroundingBlocks[b][1])].blockType === blockType) {
+      if (surroundingBlocks[b][0] && this.actionPlane.getBlock(this.coordinatesToIndex(surroundingBlocks[b][1])).blockType === blockType) {
         surroundingBlocks[b][0] = false;
       }
     }
@@ -673,7 +673,7 @@ module.exports = class LevelModel {
     }
     let plane = this.getPlaneToPlaceOn(this.getMoveForwardPosition(entity));
     if (plane === this.groundPlane) {
-      if (blockType === "redstoneWire" || blockType.substring(0,5) === "rails" && this.groundPlane._data[this.groundPlane.coordinatesToIndex(this.getMoveForwardPosition())]) {
+      if (blockType === "redstoneWire" || blockType.substring(0,5) === "rails" && this.groundPlane.getBlock(this.groundPlane.coordinatesToIndex(this.getMoveForwardPosition()))) {
         return false;
       }
     }
@@ -980,7 +980,7 @@ module.exports = class LevelModel {
     for (var y = 0; y < this.planeHeight; ++y) {
       for (var x = 0; x < this.planeWidth; ++x) {
         var index = this.coordinatesToIndex([x, y]);
-        if (!this.actionPlane._data[index].isEmpty && this.actionPlane._data[index].isEmissive || this.groundPlane._data[index].isEmissive && this.actionPlane._data[index].isEmpty) {
+        if (!this.actionPlane.getBlock(index).isEmpty && this.actionPlane.getBlock(index).isEmissive || this.groundPlane.getBlock(index).isEmissive && this.actionPlane.getBlock(index).isEmpty) {
           emissives.push([x, y]);
         }
       }
@@ -1124,7 +1124,7 @@ module.exports = class LevelModel {
 
       hasRight = false;
 
-      if (this.actionPlane._data[index].isEmpty || this.actionPlane._data[index].isTransparent) {
+      if (this.actionPlane.getBlock(index).isEmpty || this.actionPlane.getBlock(index).isTransparent) {
         if (y === 0) {
           this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_Bottom' });
         }
@@ -1141,12 +1141,12 @@ module.exports = class LevelModel {
           this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_Left' });
         }
 
-        if (x < this.planeWidth - 1 && !this.actionPlane._data[this.yToIndex(y) + x + 1].getIsEmptyOrEntity()) {
+        if (x < this.planeWidth - 1 && !this.actionPlane.getBlock(this.yToIndex(y) + x + 1).getIsEmptyOrEntity()) {
           // needs a left side AO shadow
           this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_Left' });
         }
 
-        if (x > 0 && !this.actionPlane._data[this.yToIndex(y) + x - 1].getIsEmptyOrEntity()) {
+        if (x > 0 && !this.actionPlane.getBlock(this.yToIndex(y) + x - 1).getIsEmptyOrEntity()) {
           // needs a right side AO shadow
           this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_Right' });
           this.shadingPlane.push({
@@ -1155,7 +1155,7 @@ module.exports = class LevelModel {
             type: 'Shadow_Parts_Fade_base.png'
           });
 
-          if (y > 0 && x > 0 && this.actionPlane._data[this.yToIndex(y - 1) + x - 1].getIsEmptyOrEntity()) {
+          if (y > 0 && x > 0 && this.actionPlane.getBlock(this.yToIndex(y - 1) + x - 1).getIsEmptyOrEntity()) {
             this.shadingPlane.push({
               x: x,
               y: y,
@@ -1166,30 +1166,30 @@ module.exports = class LevelModel {
           hasRight = true;
         }
 
-        if (y > 0 && !this.actionPlane._data[this.yToIndex(y - 1) + x].getIsEmptyOrEntity()) {
+        if (y > 0 && !this.actionPlane.getBlock(this.yToIndex(y - 1) + x).getIsEmptyOrEntity()) {
           // needs a bottom side AO shadow
           this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_Bottom' });
         } else if (y > 0) {
-          if (x < this.planeWidth - 1 && !this.actionPlane._data[this.yToIndex(y - 1) + x + 1].getIsEmptyOrEntity() &&
-            this.actionPlane._data[this.yToIndex(y) + x + 1].getIsEmptyOrEntity()) {
+          if (x < this.planeWidth - 1 && !this.actionPlane.getBlock(this.yToIndex(y - 1) + x + 1).getIsEmptyOrEntity() &&
+            this.actionPlane.getBlock(this.yToIndex(y) + x + 1).getIsEmptyOrEntity()) {
             // needs a bottom left side AO shadow
             this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_BottomLeft' });
           }
 
-          if (!hasRight && x > 0 && !this.actionPlane._data[this.yToIndex(y - 1) + x - 1].getIsEmptyOrEntity()) {
+          if (!hasRight && x > 0 && !this.actionPlane.getBlock(this.yToIndex(y - 1) + x - 1).getIsEmptyOrEntity()) {
             // needs a bottom right side AO shadow
             this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_BottomRight' });
           }
         }
 
         if (y < this.planeHeight - 1) {
-          if (x < this.planeWidth - 1 && !this.actionPlane._data[this.yToIndex(y + 1) + x + 1].getIsEmptyOrEntity() &&
-            this.actionPlane._data[this.yToIndex(y) + x + 1].getIsEmptyOrEntity()) {
+          if (x < this.planeWidth - 1 && !this.actionPlane.getBlock(this.yToIndex(y + 1) + x + 1).getIsEmptyOrEntity() &&
+            this.actionPlane.getBlock(this.yToIndex(y) + x + 1).getIsEmptyOrEntity()) {
             // needs a bottom left side AO shadow
             this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_TopLeft' });
           }
 
-          if (!hasRight && x > 0 && !this.actionPlane._data[this.yToIndex(y + 1) + x - 1].getIsEmptyOrEntity()) {
+          if (!hasRight && x > 0 && !this.actionPlane.getBlock(this.yToIndex(y + 1) + x - 1).getIsEmptyOrEntity()) {
             // needs a bottom right side AO shadow
             this.shadingPlane.push({ x: x, y: y, type: 'AOeffect_TopRight' });
           }

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -69,8 +69,7 @@ module.exports = class LevelModel {
 
       if (levelData.useAgent) {
         this.usingAgent = levelData.useAgent;
-        [x, y] = levelData.agentStartPosition;
-        this.agent = new Agent(this.controller, "PlayerAgent", x, y, "Agent", !this.actionPlane._data[this.yToIndex(y) + x].getIsEmptyOrEntity(), levelData.agentStartDirection);
+        this.agent = new Agent(this.controller, "PlayerAgent", x, y, "Agent", !this.actionPlane.getBlockAt(levelData.agentStartPosition).IsEmptyOrEntity(), levelData.agentStartDirection);
         this.controller.levelEntity.pushEntity(this.agent);
         this.controller.agent = this.agent;
       }

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -82,8 +82,25 @@ module.exports = class LevelPlane {
   }
 
   /**
-  * Gets the block at the desired index within the plane.
-  */
+   * Gets the block at the desired index within the plane.
+   *
+   * @param {Number} index
+   * @return {LevelBlock}
+   */
+  getBlock(index) {
+    return this._data[index];
+  }
+
+  /**
+   * Gets the block at the desired position within the plane, optionally with an
+   * offset
+   *
+   * @param {Number[]} position - [x, y] coordinates of block
+   * @param {Number} [offsetX=0]
+   * @param {Number} [offsetY=0]
+   *
+   * @return {LevelBlock}
+   */
   getBlockAt(position, offsetX = 0, offsetY = 0) {
     const [x, y] = position;
     const target = [x + offsetX, y + offsetY];

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -82,22 +82,14 @@ module.exports = class LevelPlane {
   }
 
   /**
-   * get the total number of blocks in this place
+   * Retrieve all the [x, y] coordinates within this plane
    *
-   * @return {Number}
+   * @return {[Number, Number][]}
    */
-  getBlockCount() {
-    return this._data.length;
-  }
-
-  /**
-   * Gets the block at the desired index within the plane.
-   *
-   * @param {Number} index
-   * @return {LevelBlock}
-   */
-  getBlock(index) {
-    return this._data[index];
+  getAllPositions() {
+    return this._data.map((_, i) => {
+      return this.indexToCoordinates(i);
+    });
   }
 
   /**

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -82,6 +82,15 @@ module.exports = class LevelPlane {
   }
 
   /**
+   * get the total number of blocks in this place
+   *
+   * @return {Number}
+   */
+  getBlockCount() {
+    return this._data.length;
+  }
+
+  /**
    * Gets the block at the desired index within the plane.
    *
    * @param {Number} index

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1163,10 +1163,10 @@ module.exports = class LevelView {
     this.actionPlaneBlocks = [];
     for (y = 0; y < this.controller.levelModel.planeHeight; ++y) {
       for (x = 0; x < this.controller.levelModel.planeWidth; ++x) {
-        let blockIndex = (this.yToIndex(y)) + x;
+        let position = [x, y];
         sprite = null;
 
-        const groundBlock = levelData.groundDecorationPlane.getBlock(blockIndex);
+        const groundBlock = levelData.groundDecorationPlane.getBlockAt(position);
         if (!groundBlock.isEmpty) {
           sprite = this.createBlock(this.actionPlane, x, y, groundBlock.blockType);
           if (sprite) {
@@ -1175,8 +1175,8 @@ module.exports = class LevelView {
         }
 
         sprite = null;
-        if (!levelData.actionPlane.getBlock(blockIndex).isEmpty) {
-          blockType = levelData.actionPlane.getBlock(blockIndex).blockType;
+        if (!levelData.actionPlane.getBlockAt(position).isEmpty) {
+          blockType = levelData.actionPlane.getBlockAt(position).blockType;
           sprite = this.createBlock(this.actionPlane, x, y, blockType);
           if (sprite !== null) {
             sprite.sortOrder = this.yToIndex(y);
@@ -1189,9 +1189,9 @@ module.exports = class LevelView {
 
     for (y = 0; y < this.controller.levelModel.planeHeight; ++y) {
       for (x = 0; x < this.controller.levelModel.planeWidth; ++x) {
-        let blockIndex = (this.yToIndex(y)) + x;
-        if (!levelData.fluffPlane.getBlock(blockIndex).isEmpty) {
-          sprite = this.createBlock(this.fluffPlane, x, y, levelData.fluffPlane.getBlock(blockIndex).blockType);
+        let position = [x, y];
+        if (!levelData.fluffPlane.getBlockAt(position).isEmpty) {
+          sprite = this.createBlock(this.fluffPlane, x, y, levelData.fluffPlane.getBlockAt(position).blockType);
         }
       }
     }
@@ -1201,8 +1201,8 @@ module.exports = class LevelView {
     this.groundPlane.removeAll(true);
     for (var y = 0; y < this.controller.levelModel.planeHeight; ++y) {
       for (var x = 0; x < this.controller.levelModel.planeWidth; ++x) {
-        let blockIndex = (this.yToIndex(y)) + x;
-        var sprite = this.createBlock(this.groundPlane, x, y, this.controller.levelModel.groundPlane.getBlock(blockIndex).blockType);
+        let position = [x, y];
+        var sprite = this.createBlock(this.groundPlane, x, y, this.controller.levelModel.groundPlane.getBlockAt(position).blockType);
         if (sprite) {
           sprite.sortOrder = this.yToIndex(y);
         }
@@ -1943,8 +1943,10 @@ module.exports = class LevelView {
     this.setSelectionIndicatorPosition(this.controller.levelModel.actionPlane.indexToCoordinates(index)[0], this.controller.levelModel.actionPlane.indexToCoordinates(index)[1]);
     this.controller.audioPlayer.play("doorOpen");
     // If it's not walable, then open otherwise, close.
-    this.playDoorAnimation(this.controller.levelModel.actionPlane.indexToCoordinates(index), open, () => {
-      this.controller.levelModel.actionPlane.getBlock(index).isWalkable = !this.controller.levelModel.actionPlane.getBlock(index).isWalkable;
+    const position = this.controller.levelModel.actionPlane.indexToCoordinates(index);
+    this.playDoorAnimation(position, open, () => {
+      const block = this.controller.levelModel.actionPlane.getBlockAt(position);
+      block.isWalkable = !block.isWalkable;
       this.playIdleAnimation(player.position, player.facing, player.isOnBlock);
       this.setSelectionIndicatorPosition(player.position[0], player.position[1]);
     });

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1166,16 +1166,17 @@ module.exports = class LevelView {
         let blockIndex = (this.yToIndex(y)) + x;
         sprite = null;
 
-        if (!levelData.groundDecorationPlane._data[blockIndex].isEmpty) {
-          sprite = this.createBlock(this.actionPlane, x, y, levelData.groundDecorationPlane._data[blockIndex].blockType);
+        const groundBlock = levelData.groundDecorationPlane.getBlock(blockIndex);
+        if (!groundBlock.isEmpty) {
+          sprite = this.createBlock(this.actionPlane, x, y, groundBlock.blockType);
           if (sprite) {
             sprite.sortOrder = this.yToIndex(y);
           }
         }
 
         sprite = null;
-        if (!levelData.actionPlane._data[blockIndex].isEmpty) {
-          blockType = levelData.actionPlane._data[blockIndex].blockType;
+        if (!levelData.actionPlane.getBlock(blockIndex).isEmpty) {
+          blockType = levelData.actionPlane.getBlock(blockIndex).blockType;
           sprite = this.createBlock(this.actionPlane, x, y, blockType);
           if (sprite !== null) {
             sprite.sortOrder = this.yToIndex(y);
@@ -1189,8 +1190,8 @@ module.exports = class LevelView {
     for (y = 0; y < this.controller.levelModel.planeHeight; ++y) {
       for (x = 0; x < this.controller.levelModel.planeWidth; ++x) {
         let blockIndex = (this.yToIndex(y)) + x;
-        if (!levelData.fluffPlane._data[blockIndex].isEmpty) {
-          sprite = this.createBlock(this.fluffPlane, x, y, levelData.fluffPlane._data[blockIndex].blockType);
+        if (!levelData.fluffPlane.getBlock(blockIndex).isEmpty) {
+          sprite = this.createBlock(this.fluffPlane, x, y, levelData.fluffPlane.getBlock(blockIndex).blockType);
         }
       }
     }
@@ -1201,7 +1202,7 @@ module.exports = class LevelView {
     for (var y = 0; y < this.controller.levelModel.planeHeight; ++y) {
       for (var x = 0; x < this.controller.levelModel.planeWidth; ++x) {
         let blockIndex = (this.yToIndex(y)) + x;
-        var sprite = this.createBlock(this.groundPlane, x, y, this.controller.levelModel.groundPlane._data[blockIndex].blockType);
+        var sprite = this.createBlock(this.groundPlane, x, y, this.controller.levelModel.groundPlane.getBlock(blockIndex).blockType);
         if (sprite) {
           sprite.sortOrder = this.yToIndex(y);
         }
@@ -1943,7 +1944,7 @@ module.exports = class LevelView {
     this.controller.audioPlayer.play("doorOpen");
     // If it's not walable, then open otherwise, close.
     this.playDoorAnimation(this.controller.levelModel.actionPlane.indexToCoordinates(index), open, () => {
-      this.controller.levelModel.actionPlane._data[index].isWalkable = !this.controller.levelModel.actionPlane._data[index].isWalkable;
+      this.controller.levelModel.actionPlane.getBlock(index).isWalkable = !this.controller.levelModel.actionPlane.getBlock(index).isWalkable;
       this.playIdleAnimation(player.position, player.facing, player.isOnBlock);
       this.setSelectionIndicatorPosition(player.position[0], player.position[1]);
     });


### PR DESCRIPTION
In response to https://github.com/code-dot-org/craft/pull/99

Added a `getAllPositions` method for operations which want to examine all blocks on a plane, and updated everything to use `getBlockAt` positional access rather than index access.

Note that this required updating in a couple of places the way we're approaching an operation, and in a couple of other places it requires awkwardly converting indexes to positions. I think for the former considerations all the changes resulted in improved code, and in the latter consideration it serves to highlight the fact that we would probably prefer to be using positions more universally.