### PR TITLE
Fix two bugs preventing the playground from loading

### DIFF
--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -69,7 +69,8 @@ module.exports = class LevelModel {
 
       if (levelData.useAgent) {
         this.usingAgent = levelData.useAgent;
-        this.agent = new Agent(this.controller, "PlayerAgent", x, y, "Agent", !this.actionPlane.getBlockAt(levelData.agentStartPosition).IsEmptyOrEntity(), levelData.agentStartDirection);
+        const startingBlock = this.actionPlane.getBlockAt(levelData.agentStartPosition);
+        this.agent = new Agent(this.controller, "PlayerAgent", x, y, "Agent", !startingBlock.getIsEmptyOrEntity(), levelData.agentStartDirection);
         this.controller.levelEntity.pushEntity(this.agent);
         this.controller.agent = this.agent;
       }

--- a/src/test-build-only/levels.js
+++ b/src/test-build-only/levels.js
@@ -52,7 +52,8 @@ window.demoLevels = {
       return false;
     },
 
-    groundPlane: ["grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
+    groundPlane: [
+      "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
       "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
       "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
       "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass", "grass",
@@ -87,7 +88,6 @@ window.demoLevels = {
       "", "", "", "redstoneWire", "redstoneWire", "redstoneWire", "redstoneWire", "redstoneWire", "pistonUp", "",
       "", "", "", "redstoneWire", "", "", "", "", "", "",
       "", "grass", "oreDiamond", "pistonLeft", "", "", "", "", "", "",
-      "", "", "", "", "", "", "", "", "", "",
       "", "", "", "", "", "", "", "", "", "",
     ],
 


### PR DESCRIPTION
1. The definition of the test level was invalidly using a 10x11 grid for
_only one_ plane. All plane definitions need to be the same dimensions;
removed the offending row.

2. The agent placement logic was attempting to call a block function
that does not exist; renamed isEmptyOrEntity to getIsEmptyOrEntity