### PR TITLE
player (and other entities) should be able to move through agent

### DIFF
--- a/src/js/game/Entities/Agent.js
+++ b/src/js/game/Entities/Agent.js
@@ -45,6 +45,15 @@ module.exports = class Agent extends BaseEntity {
     return true;
   }
 
+  /**
+   * Give agent a higher-than-normal offset so that it will always render on top
+   * of the player when on the same cell.
+   * @override
+   */
+  getSortOrderOffset() {
+    return super.getSortOrderOffset() + 1;
+  }
+
   // "Events" levels allow the player to move around with the arrow keys, and
   // perform actions with the space bar.
   updateMovement() {

--- a/src/js/game/Entities/Agent.js
+++ b/src/js/game/Entities/Agent.js
@@ -38,6 +38,13 @@ module.exports = class Agent extends BaseEntity {
     return result;
   }
 
+  /**
+   * @override
+   */
+  canMoveThrough() {
+    return true;
+  }
+
   // "Events" levels allow the player to move around with the arrow keys, and
   // perform actions with the space bar.
   updateMovement() {

--- a/src/js/game/Entities/BaseEntity.js
+++ b/src/js/game/Entities/BaseEntity.js
@@ -30,6 +30,17 @@ module.exports = class BaseEntity {
     return false;
   }
 
+  /**
+   * For entities which need to be able to accomodate rendering in the same
+   * cell as other entities, provide a way to define a rendering offset.
+   *
+   * @see LevelView.playPlayerAnimation
+   * @see LevelView.playMoveForwardAnimation
+   * @return Number
+   */
+  getSortOrderOffset() {
+    return 5;
+  }
 
   addCommand(commandQueueItem, repeat = false) {
     this.queue.addCommand(commandQueueItem, repeat);

--- a/src/js/game/Entities/BaseEntity.js
+++ b/src/js/game/Entities/BaseEntity.js
@@ -4,63 +4,64 @@ const EventType = require("../Event/EventType.js");
 const CallbackCommand = require("../CommandQueue/CallbackCommand.js");
 
 module.exports = class BaseEntity {
-    constructor(controller, type, identifier, x, y, facing) {
-        this.queue = new CommandQueue(controller);
-        this.controller = controller;
-        this.game = controller.game;
-        this.position = [x, y];
-        this.type = type;
-        // temp
-        this.facing = facing;
-        // offset for sprite position in grid
-        this.offset = [-22, -12];
-        this.identifier = identifier;
-        this.healthPoint = 3;
-        this.underTree = { state: false, treeIndex: -1 };
-    }
+  constructor(controller, type, identifier, x, y, facing) {
+    this.queue = new CommandQueue(controller);
+    this.controller = controller;
+    this.game = controller.game;
+    this.position = [x, y];
+    this.type = type;
+    // temp
+    this.facing = facing;
+    // offset for sprite position in grid
+    this.offset = [-22, -12];
+    this.identifier = identifier;
+    this.healthPoint = 3;
+    this.underTree = { state: false, treeIndex: -1 };
+  }
 
-    tick() {
-        this.queue.tick();
-    }
+  tick() {
+      this.queue.tick();
+  }
 
-    reset() {
-    }
+  reset() {
+  }
 
-    canMoveThrough() {
-      return false;
-    }
+  canMoveThrough() {
+    return false;
+  }
 
-    addCommand(commandQueueItem, repeat = false) {
-        this.queue.addCommand(commandQueueItem, repeat);
-        // execute the command
-        this.queue.begin();
-    }
 
-    playMoveForwardAnimation(position, facing, commandQueueItem, groundType) {
-        var levelView = this.controller.levelView;
-        var tween;
-        // update z order
-        var zOrderYIndex = position[1] + (facing === FacingDirection.North ? 1 : 0);
-        this.sprite.sortOrder = this.controller.levelView.yToIndex(zOrderYIndex) + 1;
-        // stepping sound
-        levelView.playBlockSound(groundType);
-        // play walk animation
-        var animName = "walk" + this.controller.levelView.getDirectionName(this.facing);
-        var idleAnimName = "idle" + this.controller.levelView.getDirectionName(this.facing);
-        levelView.playScaledSpeed(this.sprite.animations, animName);
-        setTimeout(() => {
-            tween = this.controller.levelView.addResettableTween(this.sprite).to({
-                x: (this.offset[0] + 40 * position[0]), y: (this.offset[1] + 40 * position[1])
-            }, 300, Phaser.Easing.Linear.None);
-            tween.onComplete.add(() => {
-                levelView.playScaledSpeed(this.sprite.animations, idleAnimName);
-                commandQueueItem.succeeded();
-            });
+  addCommand(commandQueueItem, repeat = false) {
+    this.queue.addCommand(commandQueueItem, repeat);
+    // execute the command
+    this.queue.begin();
+  }
 
-            tween.start();
-        }, 50 / this.controller.tweenTimeScale);
-        // smooth movement using tween
-    }
+  playMoveForwardAnimation(position, facing, commandQueueItem, groundType) {
+    var levelView = this.controller.levelView;
+    var tween;
+    // update z order
+    var zOrderYIndex = position[1] + (facing === FacingDirection.North ? 1 : 0);
+    this.sprite.sortOrder = this.controller.levelView.yToIndex(zOrderYIndex) + 1;
+    // stepping sound
+    levelView.playBlockSound(groundType);
+    // play walk animation
+    var animName = "walk" + this.controller.levelView.getDirectionName(this.facing);
+    var idleAnimName = "idle" + this.controller.levelView.getDirectionName(this.facing);
+    levelView.playScaledSpeed(this.sprite.animations, animName);
+    setTimeout(() => {
+      tween = this.controller.levelView.addResettableTween(this.sprite).to({
+        x: (this.offset[0] + 40 * position[0]), y: (this.offset[1] + 40 * position[1])
+      }, 300, Phaser.Easing.Linear.None);
+      tween.onComplete.add(() => {
+        levelView.playScaledSpeed(this.sprite.animations, idleAnimName);
+        commandQueueItem.succeeded();
+      });
+
+      tween.start();
+    }, 50 / this.controller.tweenTimeScale);
+    // smooth movement using tween
+  }
 
   /**
    * player walkable stuff

--- a/src/js/game/Entities/BaseEntity.js
+++ b/src/js/game/Entities/BaseEntity.js
@@ -24,7 +24,10 @@ module.exports = class BaseEntity {
     }
 
     reset() {
+    }
 
+    canMoveThrough() {
+      return false;
     }
 
     addCommand(commandQueueItem, repeat = false) {
@@ -57,7 +60,6 @@ module.exports = class BaseEntity {
             tween.start();
         }, 50 / this.controller.tweenTimeScale);
         // smooth movement using tween
-
     }
 
   /**
@@ -572,7 +574,7 @@ module.exports = class BaseEntity {
         // action plane is empty
         && !actionBlock.isEmpty))
         // there is no entity
-        && (frontEntity === undefined)
+        && (frontEntity === undefined || frontEntity.canMoveThrough())
         // no lava or water
         && (groundBlock.blockType !== "water" && groundBlock.blockType !== "lava");
   }

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -418,7 +418,7 @@ module.exports = class LevelView {
 
   playPlayerAnimation(animationName, position, facing, isOnBlock = false, entity = this.player) {
     let direction = this.getDirectionName(facing);
-    entity.sprite.sortOrder = this.yToIndex(position[1]) + 5;
+    entity.sprite.sortOrder = this.yToIndex(position[1]) + entity.getSortOrderOffset();
 
     let animName = animationName + direction;
     return this.playScaledSpeed(entity.sprite.animations, animName);
@@ -818,7 +818,7 @@ module.exports = class LevelView {
     this.setSelectionIndicatorPosition(position[0], position[1]);
     //make sure to render high for when moving up after placing a block
     var zOrderYIndex = position[1] + (facing === FacingDirection.North ? 1 : 0);
-    entity.sprite.sortOrder = this.yToIndex(zOrderYIndex) + 5;
+    entity.sprite.sortOrder = this.yToIndex(zOrderYIndex) + entity.getSortOrderOffset();
 
     if (!shouldJumpDown) {
       const animName = "walk" + this.getDirectionName(facing);
@@ -846,7 +846,7 @@ module.exports = class LevelView {
     this.setSelectionIndicatorPosition(position[0], position[1]);
     //make sure to render high for when moving up after placing a block
     var zOrderYIndex = position[1] + (facing === FacingDirection.North ? 1 : 0);
-    entity.sprite.sortOrder = this.yToIndex(zOrderYIndex) + 5;
+    entity.sprite.sortOrder = this.yToIndex(zOrderYIndex) + entity.getSortOrderOffset();
 
     if (!shouldJumpDown) {
       const animName = animation + this.getDirectionName(facing);
@@ -1241,7 +1241,7 @@ module.exports = class LevelView {
     const screen = this.positionToScreen([x, y], isOnBlock, entity);
     entity.sprite.x = screen.x;
     entity.sprite.y = screen.y;
-    entity.sprite.sortOrder = this.yToIndex(screen.y) + 5;
+    entity.sprite.sortOrder = this.yToIndex(screen.y) + entity.getSortOrderOffset();
   }
 
   setSelectionIndicatorPosition(x, y) {


### PR DESCRIPTION
Implemented by adding a `canMoveThrough` method to entities (which agent overrides), specifying whether or not other entities can move through them.

Also added a `getSortOrderOffset` method for retrieving the sort order offset (which agent also overrides), rather than hardcoding `5` everywhere.

Note that you should probably view the diff [with withspace ignored](https://github.com/code-dot-org/craft/pull/120/files?w=1) as I also fixed some weird whitespace in BaseEntity