### PR TITLE
add getIsDirectPlayerControl helper to replace isEventLevel for character movement logic

### DIFF
--- a/src/js/game/Entities/Agent.js
+++ b/src/js/game/Entities/Agent.js
@@ -10,7 +10,7 @@ module.exports = class Agent extends BaseEntity {
     this.inventory = {};
     this.movementState = -1;
 
-    if (controller.levelData.isEventLevel) {
+    if (controller.getIsDirectPlayerControl()) {
       this.moveDelayMin = 0;
       this.moveDelayMax = 0;
     } else {
@@ -22,7 +22,7 @@ module.exports = class Agent extends BaseEntity {
   // "Events" levels allow the player to move around with the arrow keys, and
   // perform actions with the space bar.
   updateMovement() {
-    if (!this.controller.attemptRunning || !this.controller.levelData.isEventLevel) {
+    if (!this.controller.attemptRunning || !this.controller.getIsDirectPlayerControl()) {
       return;
     }
     const queueIsEmpty = this.queue.isFinished() || !this.queue.isStarted();

--- a/src/js/game/Entities/Player.js
+++ b/src/js/game/Entities/Player.js
@@ -10,7 +10,7 @@ module.exports = class Player extends BaseEntity {
     this.inventory = {};
     this.movementState = -1;
 
-    if (controller.levelData.isEventLevel) {
+    if (controller.getIsDirectPlayerControl()) {
       this.moveDelayMin = 0;
       this.moveDelayMax = 0;
     } else {
@@ -22,7 +22,7 @@ module.exports = class Player extends BaseEntity {
   // "Events" levels allow the player to move around with the arrow keys, and
   // perform actions with the space bar.
   updateMovement() {
-    if (!this.controller.attemptRunning || !this.controller.levelData.isEventLevel) {
+    if (!this.controller.attemptRunning || !this.controller.getIsDirectPlayerControl()) {
       return;
     }
     const queueIsEmpty = this.queue.isFinished() || !this.queue.isStarted();

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -118,6 +118,16 @@ class GameController {
   }
 
   /**
+   * Is this one of those level types in which the player is controlled by arrow
+   * keys rather than by blocks?
+   *
+   * @return {boolean}
+   */
+  getIsDirectPlayerControl() {
+    return this.levelData.isEventLevel || this.levelData.isAgentLevel;
+  }
+
+  /**
    * @param {Object} levelConfig
    */
   loadLevel(levelConfig) {
@@ -248,7 +258,7 @@ class GameController {
 
     // Check for completion every frame for "event" levels. For procedural
     // levels, only check completion after the player has run all commands.
-    if (this.levelData.isEventLevel || this.player.queue.state > 1) {
+    if (this.getIsDirectPlayerControl() || this.player.queue.state > 1) {
       this.checkSolution();
     }
   }
@@ -1533,7 +1543,7 @@ class GameController {
       } else {
         this.endLevel(true);
       }
-    } else if (this.levelModel.isFailed() || !this.levelData.isEventLevel) {
+    } else if (this.levelModel.isFailed() || !this.getIsDirectPlayerControl()) {
       // For "Events" levels, check the final state to see if it's failed.
       // Procedural levels only call `checkSolution` after all code has run, so
       // fail if we didn't pass the success condition.

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -613,15 +613,17 @@ module.exports = class LevelModel {
         }
         result.push("notEmpty");
       }
-      // Only prevent walking into water/lava in "Events" levels.
+      // Prevent walking into water/lava in levels where the player is
+      // controlled by arrow keys. In levels where the player is controlled by
+      // blocks, let them drown.
       if (this.groundPlane.getBlockAt(position).blockType === "water") {
-        if (this.controller.levelData.isEventLevel) {
+        if (this.controller.getIsDirectPlayerControl()) {
           result.push("water");
         } else {
           return [true];
         }
       } else if (this.groundPlane.getBlockAt(position).blockType === "lava") {
-        if (this.controller.levelData.isEventLevel) {
+        if (this.controller.getIsDirectPlayerControl()) {
           result.push("lava");
         } else {
           return [true];

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1049,14 +1049,14 @@ module.exports = class LevelView {
       this.toDestroy.push(explodeAnim);
 
       if (placeBlock) {
-        if (!this.controller.levelData.isEventLevel) {
+        if (!this.controller.getIsDirectPlayerControl()) {
           this.playPlayerAnimation("idle", playerPosition, facing, false, entity);
         }
         this.playItemDropAnimation(destroyPosition, blockType, completionHandler);
       }
     });
     this.playScaledSpeed(explodeAnim.animations, "explode");
-    if (this.controller.levelData.isEventLevel ^ !placeBlock) {
+    if (this.controller.getIsDirectPlayerControl() ^ !placeBlock) {
       completionHandler();
     }
   }
@@ -1067,7 +1067,7 @@ module.exports = class LevelView {
       sprite.sortOrder = this.yToIndex(destroyPosition[1]) + 2;
     }
 
-    if (this.controller.levelData.isEventLevel) {
+    if (this.controller.getIsDirectPlayerControl()) {
       completionHandler();
     } else {
       this.onAnimationEnd(this.playScaledSpeed(sprite.animations, "animate"), () => {
@@ -1614,7 +1614,7 @@ module.exports = class LevelView {
     sprite = this.actionPlane.create(xOffset + 40 * x, yOffset + this.actionPlane.yOffset + 40 * y, atlas, "");
     const anim = sprite.animations.add("animate", frameList, 10, false);
 
-    if (this.controller.levelData.isEventLevel) {
+    if (this.controller.getIsDirectPlayerControl()) {
       const distanceBetween = function (position, position2) {
         return Math.sqrt(Math.pow(position[0] - position2[0], 2) + Math.pow(position[1] - position2[1], 2));
       };

--- a/test/unit/LevelModelTest.js
+++ b/test/unit/LevelModelTest.js
@@ -22,6 +22,7 @@ const makeLevelDefinition = (width, height) => {
 
 const mockGameController = {
   levelEntity: new LevelEntity({}),
+  getIsDirectPlayerControl: () => false,
   levelData: {},
 };
 


### PR DESCRIPTION
This is necessary to enable the `isAgentLevel` setting to distinguish from `isEventLevel`