### PR TITLE
fix player idle animation to not always face south

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1596,7 +1596,7 @@ module.exports = class LevelView {
       frameList.push(this.playerFrameName(offset + 1));
     }
     entity.sprite.animations.add('idlePause' + direction, frameList, frameRate / 3, false).onComplete.add(() => {
-      this.playRandomPlayerIdle(FacingDirection.South);
+      this.playRandomPlayerIdle(facing);
     });
 
     entity.sprite.animations.add('walk' + direction, Phaser.Animation.generateFrameNames("Player_", offset + 13, offset + 20, "", 3), frameRate, true);


### PR DESCRIPTION
Looks like when we generalized the animation generation, one animation got left hardcoded to South, resulting in the player idle animation eventually turning the player to _appear_ as if they were facing south, no matter which direction they are actually facing.

The fix is fortunately simple