### PR TITLE
Handle destroying a blockType with no associated miniblock

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1657,6 +1657,10 @@ module.exports = class LevelView {
       frameList;
 
     const frame = LevelBlock.getMiniblockFrame(blockType);
+    if (!frame) {
+      return sprite;
+    }
+
     const atlas = "miniBlocks";
     const framePrefix = this.miniBlocks[frame][0];
     const frameStart = this.miniBlocks[frame][1];


### PR DESCRIPTION
fixes #150
fixes #147
fixes #145
fixes #144
fixes #137
fixes #126