### PR TITLE
Agent can trigger pressure plates

### DIFF
--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -822,11 +822,12 @@ class GameController {
 
   moveDirection(commandQueueItem, direction) {
     let player = this.getEntity(commandQueueItem.target);
+
     let isMovingOffOf = this.levelModel.isEntityOnBlocktype(commandQueueItem.target, "pressurePlateDown");
     if (isMovingOffOf) {
       let position = player.position;
       let block = new LevelBlock('pressurePlateUp');
-      let offset = this.directionToOffet(direction);
+      let offset = this.directionToOffset(direction);
       this.levelModel.actionPlane.setBlockAt(position, block, offset[0], offset[1]);
     }
     let outOfDoor = this.levelModel.isEntityOnBlocktype(commandQueueItem.target, "doorIron");
@@ -854,13 +855,14 @@ class GameController {
       }
       commandQueueItem.succeeded();
     }
+
     let isMovingOnToPlate = this.levelModel.isEntityOnBlocktype(commandQueueItem.target, "pressurePlateUp");
     let destinationBlock = this.levelModel.actionPlane.getBlockAt(player.position);
     if (isMovingOnToPlate) {
       let position = player.position;
       let block = new LevelBlock('pressurePlateDown');
       direction = (direction + 2) % 4;
-      let offset = this.directionToOffet(direction);
+      let offset = this.directionToOffset(direction);
       this.levelModel.actionPlane.setBlockAt(position, block, offset[0], offset[1]);
     } else {
       if (outOfDoor && destinationBlock.blockType !== "doorIron") {
@@ -869,7 +871,7 @@ class GameController {
     }
   }
 
-  directionToOffet(direction) {
+  directionToOffset(direction) {
     let offset = [0,0];
     // Direction will ever only not be null if we're calling this as a
     // function of player movement.

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -801,7 +801,10 @@ class GameController {
   }
 
   moveForward(commandQueueItem) {
-    let target = commandQueueItem.target;
+    const target = commandQueueItem.target;
+    const moveOffset = this.directionToOffset(target.facing);
+    this.handleMoveOffPressurePlate(commandQueueItem, moveOffset);
+
     if (!this.isType(target)) {
       // apply to all entities
       if (target === undefined) {
@@ -824,10 +827,16 @@ class GameController {
       }
       commandQueueItem.succeeded();
     }
+
+    this.handleMoveOnPressurePlate(commandQueueItem, moveOffset);
+    this.handleMoveOffIronDoor(commandQueueItem, moveOffset);
   }
 
   moveBackward(commandQueueItem) {
-    let target = commandQueueItem.target;
+    const target = commandQueueItem.target;
+    const moveOffset = this.directionToOffset(FacingDirection.opposite(target.facing));
+    this.handleMoveOffPressurePlate(commandQueueItem, moveOffset);
+
     if (!this.isType(target)) {
       // apply to all entities
       if (target === undefined) {
@@ -850,6 +859,9 @@ class GameController {
       }
       commandQueueItem.succeeded();
     }
+
+    this.handleMoveOnPressurePlate(commandQueueItem, moveOffset);
+    this.handleMoveOffIronDoor(commandQueueItem, moveOffset);
   }
 
   moveDirection(commandQueueItem, direction) {


### PR DESCRIPTION
Pressure Plate (and iron door double-checking) was enabled only for directional movement, not for the Forward/Backward movement that the Agent uses.

(As an aside, Agent in the 2-D Craft Playground dev test environment _is_ using directional movement, which is why this bug went unnoticed)

Fixes https://github.com/code-dot-org/craft/issues/154