### PR TITLE
for level 1, we need to be able to spawn an agent on solutionCheck()

### DIFF
--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1540,7 +1540,7 @@ class GameController {
         this.levelView.playMinecartAnimation(player.isOnBlock,
           () => { this.handleEndState(true); }, this.levelModel.getUnpoweredRails());
       } else if (this.checkAgentSpawn()) {
-        this.levelModel.doAgentSpawn(null, 3, 2);
+        this.levelModel.spawnAgent(null, [3, 2], 2); // This will spawn the Agent at [3, 2], facing South.
       } else if (this.checkTntAnimation()) {
         this.resultReported = true;
         this.levelView.scaleShowWholeWorld(() => {});

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1379,6 +1379,10 @@ class GameController {
     return this.specialLevelType === 'houseBuild';
   }
 
+  checkAgentSpawn() {
+    return this.specialLevelType === 'agentSpawn';
+  }
+
   placeBlock(commandQueueItem, blockType) {
     const player = this.getEntity(commandQueueItem.target);
     const position = player.position;
@@ -1535,6 +1539,8 @@ class GameController {
         this.resultReported = true;
         this.levelView.playMinecartAnimation(player.isOnBlock,
           () => { this.handleEndState(true); }, this.levelModel.getUnpoweredRails());
+      } else if (this.checkAgentSpawn()) {
+        this.levelModel.doAgentSpawn(null, 3, 2);
       } else if (this.checkTntAnimation()) {
         this.resultReported = true;
         this.levelView.scaleShowWholeWorld(() => {});

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -68,7 +68,7 @@ module.exports = class LevelModel {
       this.controller.player = this.player;
 
       if (levelData.useAgent) {
-        this.doAgentSpawn(levelData);
+        this.spawnAgent(levelData);
       }
     }
 
@@ -76,13 +76,13 @@ module.exports = class LevelModel {
     this.computeFowPlane();
   }
 
-  doAgentSpawn(levelData = null, aX = -1, aY = -1) {
+  spawnAgent(levelData, positionOverride, directionOverride) {
     this.usingAgent = true;
     let [x, y] = [0, 0];
     let direction = 0;
     let name = "";
     let key = "";
-    if (levelData !== null) {
+    if (levelData) {
       [x, y] = levelData.agentStartPosition;
       direction = levelData.agentStartDirection;
       name = "PlayerAgent";
@@ -91,10 +91,9 @@ module.exports = class LevelModel {
       this.agent = new Agent(this.controller, name, x, y, key, !startingBlock.getIsEmptyOrEntity(), direction);
       this.controller.levelEntity.pushEntity(this.agent);
       this.controller.agent = this.agent;
-    }
-    if (aX !== -1 && aY !== -1) {
-      [x, y] = [aX, aY];
-      direction = 2;
+    } else if (positionOverride !== undefined) {
+      [x, y] = positionOverride;
+      direction = directionOverride;
       name = "PlayerAgent";
       key = "Agent";
       const startingBlock = this.actionPlane.getBlockAt([x, y]);

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -76,33 +76,32 @@ module.exports = class LevelModel {
     this.computeFowPlane();
   }
 
+  /**
+   * Creates the Agent entity
+   *
+   * @param {Object} levelData the initial level data object, specifying the
+   *        Agent's default position and direction
+   * @param {[Number, Number]} [positionOverride] optional position override
+   * @param {Number} [directionOverride] optional direction override
+   */
   spawnAgent(levelData, positionOverride, directionOverride) {
     this.usingAgent = true;
-    let [x, y] = [0, 0];
-    let direction = 0;
-    let name = "";
-    let key = "";
-    if (levelData) {
-      [x, y] = levelData.agentStartPosition;
-      direction = levelData.agentStartDirection;
-      name = "PlayerAgent";
-      key = "Agent";
-      const startingBlock = this.actionPlane.getBlockAt([x, y]);
-      this.agent = new Agent(this.controller, name, x, y, key, !startingBlock.getIsEmptyOrEntity(), direction);
-      this.controller.levelEntity.pushEntity(this.agent);
-      this.controller.agent = this.agent;
-    } else if (positionOverride !== undefined) {
-      [x, y] = positionOverride;
-      direction = directionOverride;
-      name = "PlayerAgent";
-      key = "Agent";
-      const startingBlock = this.actionPlane.getBlockAt([x, y]);
-      this.agent = new Agent(this.controller, name, x, y, key, !startingBlock.getIsEmptyOrEntity(), direction);
-      this.controller.levelEntity.pushEntity(this.agent);
-      this.controller.agent = this.agent;
 
-      this.controller.levelView.reset(this);
-    }
+    const [x, y] = (positionOverride !== undefined)
+      ? positionOverride
+      : levelData.agentStartPosition;
+
+    const direction = (directionOverride !== undefined)
+        ? directionOverride
+        : levelData.agentStartDirection;
+
+    const name = "PlayerAgent";
+    const key = "Agent";
+
+    const startingBlock = this.actionPlane.getBlockAt([x, y]);
+    this.agent = new Agent(this.controller, name, x, y, key, !startingBlock.getIsEmptyOrEntity(), direction);
+    this.controller.levelEntity.pushEntity(this.agent);
+    this.controller.agent = this.agent;
   }
 
   yToIndex(y) {

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -68,17 +68,42 @@ module.exports = class LevelModel {
       this.controller.player = this.player;
 
       if (levelData.useAgent) {
-        this.usingAgent = levelData.useAgent;
-        [x, y] = levelData.agentStartPosition;
-        const startingBlock = this.actionPlane.getBlockAt(levelData.agentStartPosition);
-        this.agent = new Agent(this.controller, "PlayerAgent", x, y, "Agent", !startingBlock.getIsEmptyOrEntity(), levelData.agentStartDirection);
-        this.controller.levelEntity.pushEntity(this.agent);
-        this.controller.agent = this.agent;
+        this.doAgentSpawn(levelData);
       }
     }
 
     this.computeShadingPlane();
     this.computeFowPlane();
+  }
+
+  doAgentSpawn(levelData = null, aX = -1, aY = -1) {
+    this.usingAgent = true;
+    let [x, y] = [0, 0];
+    let direction = 0;
+    let name = "";
+    let key = "";
+    if (levelData !== null) {
+      [x, y] = levelData.agentStartPosition;
+      direction = levelData.agentStartDirection;
+      name = "PlayerAgent";
+      key = "Agent";
+      const startingBlock = this.actionPlane.getBlockAt([x, y]);
+      this.agent = new Agent(this.controller, name, x, y, key, !startingBlock.getIsEmptyOrEntity(), direction);
+      this.controller.levelEntity.pushEntity(this.agent);
+      this.controller.agent = this.agent;
+    }
+    if (aX !== -1 && aY !== -1) {
+      [x, y] = [aX, aY];
+      direction = 2;
+      name = "PlayerAgent";
+      key = "Agent";
+      const startingBlock = this.actionPlane.getBlockAt([x, y]);
+      this.agent = new Agent(this.controller, name, x, y, key, !startingBlock.getIsEmptyOrEntity(), direction);
+      this.controller.levelEntity.pushEntity(this.agent);
+      this.controller.agent = this.agent;
+
+      this.controller.levelView.reset(this);
+    }
   }
 
   yToIndex(y) {


### PR DESCRIPTION
doAgentSpawn() is probably a bit messy. If the level is an agent level, doAgentSpawn() is called at init with a passed in levelData so you get the normal behavior. If you call it manually on a non-agent level, with a first argument of null, you spawn the agent at the index you passed in.

I've got ideas about how to clean this up, but also welcome any input you guys might want.