### PR TITLE
URGENT FIX: crash on refreshActionPlane + diamondMiniblock

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1420,7 +1420,7 @@ module.exports = class LevelView {
           return;
         }
 
-        if (newBlock && newBlock.blockType === "diamondMiniblock") {
+        if (newBlock && newBlock.getIsMiniblock()) {
           return;
         }
 

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1420,6 +1420,10 @@ module.exports = class LevelView {
           return;
         }
 
+        if (newBlock && newBlock.blockType === "diamondMiniblock") {
+          return;
+        }
+
         if (newBlock && newBlock.blockType) {
           this.createActionPlaneBlock(position, newBlock.blockType);
         } else if (newBlock) {


### PR DESCRIPTION
This is causing crashes when players try and get diamond blocks.