### PR TITLE
Allow agent to punch air

### DIFF
--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1277,13 +1277,13 @@ class GameController {
       }
       // if there is a entity in front of the player
     } else {
-      this.levelView.playPunchDestroyAirAnimation(player.position, player.facing, this.levelModel.getMoveForwardPosition(), () => {
+      this.levelView.playPunchDestroyAirAnimation(player.position, player.facing, this.levelModel.getMoveForwardPosition(player), () => {
         this.levelView.setSelectionIndicatorPosition(player.position[0], player.position[1]);
-        this.levelView.playIdleAnimation(player.position, player.facing, player.isOnBlock);
+        this.levelView.playIdleAnimation(player.position, player.facing, player.isOnBlock, player);
         this.delayPlayerMoveBy(0, 0, () => {
           commandQueueItem.succeeded();
         });
-      });
+      }, player);
     }
   }
 

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1076,8 +1076,8 @@ module.exports = class LevelView {
     this.playBlockDestroyOverlayAnimation(playerPosition, facing, destroyPosition, blockType, entity, completionHandler);
   }
 
-  playPunchDestroyAirAnimation(playerPosition, facing, destroyPosition, completionHandler) {
-    this.playPunchAnimation(playerPosition, facing, destroyPosition, "punchDestroy", completionHandler);
+  playPunchDestroyAirAnimation(playerPosition, facing, destroyPosition, completionHandler, entity = this.player) {
+    this.playPunchAnimation(playerPosition, facing, destroyPosition, "punchDestroy", completionHandler, entity);
   }
 
   playPunchAirAnimation(playerPosition, facing, destroyPosition, completionHandler, entity = this.player) {


### PR DESCRIPTION
Previously, when "destroy block" was called when the agent had no block
to destroy, we were defaulting back to calling the _player_ version of
the "punch the air" animation, rather than the _agent_ version.