### PR TITLE
Add some tweaks to diamond progression path

### DIFF
--- a/src/js/game/Entities/Player.js
+++ b/src/js/game/Entities/Player.js
@@ -195,15 +195,14 @@ module.exports = class Player extends BaseEntity {
       return Math.sqrt(Math.pow(position[0] - position2[0], 2) + Math.pow(position[1] - position2[1], 2));
     };
     for (var i = 0; i < collectibles.length; i++) {
-      let sprite = collectibles[i][0];
+      const [sprite, offset, blockType, collectibleDistance] = collectibles[i];
       // already collected item
       if (sprite === null) {
         collectibles.splice(i, 1);
-
       } else {
-        let collectiblePosition = this.controller.levelModel.spritePositionToIndex(collectibles[i][1], [sprite.x, sprite.y]);
-        if (distanceBetween(targetPosition, collectiblePosition) < 2) {
-          this.controller.levelView.playItemAcquireAnimation(this.position, this.facing, sprite, () => { }, collectibles[i][2]);
+        let collectiblePosition = this.controller.levelModel.spritePositionToIndex(offset, [sprite.x, sprite.y]);
+        if (distanceBetween(targetPosition, collectiblePosition) < collectibleDistance) {
+          this.controller.levelView.playItemAcquireAnimation(this.position, this.facing, sprite, () => { }, blockType);
           collectibles.splice(i, 1);
         }
       }

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1766,10 +1766,19 @@ module.exports = class LevelView {
    * @param {Number} x
    * @param {Number} y
    * @param {String} blockType
+   * @param {Object} [overrides] optional overrides for various defaults
+   * @param {Number} [overrides.collectibleDistance=2] distance at which the
+   *        miniblock can be collected
+   * @param {Number} [overrides.xOffsetRange=40]
+   * @param {Number} [overrides.yOffsetRange=40]
    */
-  createMiniBlock(x, y, blockType) {
+  createMiniBlock(x, y, blockType, overrides = {}) {
     let sprite = null,
       frameList;
+
+    const collectibleDistance = overrides.collectibleDistance || 2;
+    const xOffsetRange = overrides.xOffsetRange || 40;
+    const yOffsetRange = overrides.yOffsetRange || 40;
 
     const frame = LevelBlock.getMiniblockFrame(blockType);
     if (!frame) {
@@ -1780,8 +1789,8 @@ module.exports = class LevelView {
     const framePrefix = this.miniBlocks[frame][0];
     const frameStart = this.miniBlocks[frame][1];
     const frameEnd = this.miniBlocks[frame][2];
-    const xOffset = -10 - 20 + Math.random() * 40;
-    const yOffset = 0 - 20 + Math.random() * 40;
+    const xOffset = -10 - (xOffsetRange / 2) + (Math.random() * xOffsetRange);
+    const yOffset = 0 - (yOffsetRange / 2) + (Math.random() * yOffsetRange);
 
     frameList = Phaser.Animation.generateFrameNames(framePrefix, frameStart, frameEnd, ".png", 3);
     sprite = this.actionPlane.create(xOffset + 40 * x, yOffset + this.actionPlane.yOffset + 40 * y, atlas, "");
@@ -1795,7 +1804,7 @@ module.exports = class LevelView {
       const collectiblePosition = this.controller.levelModel.spritePositionToIndex([xOffset, yOffset], [sprite.x, sprite.y]);
       anim.onComplete.add(() => {
         if (this.controller.levelModel.usePlayer) {
-          if (distanceBetween(this.player.position, collectiblePosition) < 2) {
+          if (distanceBetween(this.player.position, collectiblePosition) < collectibleDistance) {
             this.playItemAcquireAnimation(this.player.position, this.player.facing, sprite, () => { }, blockType);
           } else {
             this.collectibleItems.push([sprite, [xOffset, yOffset], blockType]);

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1357,7 +1357,13 @@ module.exports = class LevelView {
         const actionBlock = levelData.actionPlane.getBlockAt(position);
         if (!actionBlock.isEmpty) {
           if (actionBlock.getIsMiniblock()) {
-            sprite = this.createMiniBlock(x, y, actionBlock.blockType);
+            // miniblocks defined on the action plane like this should have a
+            // closer collectible range and a narrower drop offset than normal
+            sprite = this.createMiniBlock(x, y, actionBlock.blockType, {
+              collectibleDistance: 1,
+              xOffsetRange: 10,
+              yOffsetRange: 10
+            });
           } else {
             sprite = this.createBlock(this.actionPlane, x, y, actionBlock.blockType);
           }

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1807,7 +1807,7 @@ module.exports = class LevelView {
           if (distanceBetween(this.player.position, collectiblePosition) < collectibleDistance) {
             this.playItemAcquireAnimation(this.player.position, this.player.facing, sprite, () => { }, blockType);
           } else {
-            this.collectibleItems.push([sprite, [xOffset, yOffset], blockType]);
+            this.collectibleItems.push([sprite, [xOffset, yOffset], blockType, collectibleDistance]);
           }
         }
       });


### PR DESCRIPTION
We have slightly different requirements for Diamond miniblocks than we do for the standard miniblocks dropped when destroying other blocks. Namely, we want the collectible range to be quite a bit smaller, so you have to actually land on the diamond's square to collect it, and we also want the randomized drop location to be a bit less variable, so it's guaranteed to always be visually obvious which square the diamond is actually on.

This PR represents one such approach to implementing those requirements. Another way to do it would be to override miniblock behavior for all of agent, so that the miniblocks defined at level-creation time behave exactly the same as standard miniblocks. This would have the advantage of a more consistent user experience, but I think that having these diamonds be _inconsistent_ is actually kind of desirable. I'm definitely open to thoughts on that.