### PR TITLE
Don't fade transparent blocks when an entity stands to the north

### DIFF
--- a/src/js/game/Entities/BaseEntity.js
+++ b/src/js/game/Entities/BaseEntity.js
@@ -121,10 +121,13 @@ module.exports = class BaseEntity {
     }
 
     updateHidingBlock(prevPosition) {
-        var levelView = this.controller.levelView;
+        const levelView = this.controller.levelView;
+        const actionPlane = this.controller.levelModel.actionPlane;
+
         let frontBlockCheck = function (entity, position) {
             let frontPosition = [position[0], position[1] + 1];
-            if (frontPosition[1] < 10) {
+            const frontBlock = actionPlane.getBlockAt(frontPosition);
+            if (frontBlock && !frontBlock.isTransparent) {
                 var sprite = levelView.actionPlaneBlocks[levelView.coordinatesToIndex(frontPosition)];
                 if (sprite !== null) {
                     var tween = entity.controller.levelView.addResettableTween(sprite).to({


### PR DESCRIPTION
Resolves https://github.com/code-dot-org/craft/issues/210.

Before: (hard to see in the gif, but the Redstone and Rail tiles south of the entity fade out when the player walks one grid north of the tile)

![hiding-block-fade-before](https://user-images.githubusercontent.com/413693/31237944-2f30b884-a9ad-11e7-8b71-2442c6377b36.gif)

After: (no fade)

![hiding-block-fade-after](https://user-images.githubusercontent.com/413693/31237995-51329fc4-a9ad-11e7-9d36-9372e884aac9.gif)