### PR TITLE
Support blocks that believe they should drop a miniblock, but for which the level view has no mini block frame data

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1792,7 +1792,7 @@ module.exports = class LevelView {
     const yOffsetRange = overrides.yOffsetRange || 40;
 
     const frame = LevelBlock.getMiniblockFrame(blockType);
-    if (!frame) {
+    if (!(frame && this.miniBlocks[frame])) {
       return sprite;
     }
 


### PR DESCRIPTION
Fixes #137