### PR TITLE
Add redstone torch, pressure plate & pistons to the playground

### DIFF
--- a/src/index.html.ejs
+++ b/src/index.html.ejs
@@ -9,7 +9,7 @@
   <script src="test-build-only/jquery-1.7.min.js"></script>
   <script src="test-build-only/soundEffects.js"></script>
   <script src="test-build-only/levels.js"></script>
-  <title>2-D Craft Playground</title>
+  <title>2D Craft Playground</title>
 </head>
 <body>
 
@@ -25,9 +25,13 @@
   <select id="block-type">
     <option>rails</option>
     <option>railsUnpowered</option>
+    <option>railsRedstoneTorch</option>
     <option>redstoneWire</option>
+    <option>pressurePlateUp</option>
     <option>grass</option>
     <option>cobblestone</option>
+    <option>pistonRight</option>
+    <option>pistonLeft</option>
   </select>
 </p>
 


### PR DESCRIPTION
Make it possible to place more blocks in the playground from the dropdown menu.