### PR TITLE
In Agent levels, allow the Player to move as soon as the game loads

### DIFF
--- a/src/js/game/Entities/Player.js
+++ b/src/js/game/Entities/Player.js
@@ -48,7 +48,8 @@ module.exports = class Player extends BaseEntity {
   // "Events" levels allow the player to move around with the arrow keys, and
   // perform actions with the space bar.
   updateMovement() {
-    if (!this.controller.attemptRunning || !this.controller.getIsDirectPlayerControl()) {
+    const allowMovement = this.controller.attemptRunning || this.controller.getCanMoveBeforeRunButtonClick();
+    if (!this.controller.getIsDirectPlayerControl() || !allowMovement) {
       return;
     }
 

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -128,6 +128,14 @@ class GameController {
   }
 
   /**
+   * Can the Player move as soon as the level loads?
+   * @return {boolean}
+   */
+  getCanMoveBeforeRunButtonClick() {
+    return this.levelData.isAgentLevel;
+  }
+
+  /**
    * @param {Object} levelConfig
    */
   loadLevel(levelConfig) {


### PR DESCRIPTION
This is something we want to try out for the next in-classroom test.  It would allow the Player to explore the level before the student decides to run the Agent code.  They'll still need the Agent's help to solve the puzzle, but they can experiment with pressure plates etc. to see what they control before writing code to solve the puzzle.