### PR TITLE
Update sortOrder Index during movement animation, rather than before

### DIFF
--- a/src/js/game/Entities/Agent.js
+++ b/src/js/game/Entities/Agent.js
@@ -146,7 +146,7 @@ module.exports = class Agent extends BaseEntity {
       groundType = levelModel.actionPlane.getBlockAt(player.position).blockType;
     }
 
-    levelView.playMoveBackwardAnimation(player, prevPosition, player.facing, jumpOff, player.isOnBlock, groundType, "walk", () => {
+    levelView.playMoveBackwardAnimation(player, prevPosition, player.facing, jumpOff, player.isOnBlock, groundType, () => {
       levelView.playIdleAnimation(player.position, player.facing, player.isOnBlock, player);
 
       if (levelModel.isPlayerStandingInWater()) {

--- a/src/js/game/Entities/Player.js
+++ b/src/js/game/Entities/Player.js
@@ -144,7 +144,7 @@ module.exports = class Player extends BaseEntity {
       groundType = levelModel.actionPlane.getBlockAt(player.position).blockType;
     }
 
-    levelView.playMoveBackwardAnimation(player, prevPosition, player.facing, jumpOff, player.isOnBlock, groundType, "walk", () => {
+    levelView.playMoveBackwardAnimation(player, prevPosition, player.facing, jumpOff, player.isOnBlock, groundType, () => {
       levelView.playIdleAnimation(player.position, player.facing, player.isOnBlock, player);
 
       if (levelModel.isPlayerStandingInWater()) {

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -897,7 +897,6 @@ module.exports = class LevelView {
     this.playBlockSound(groundType);
 
     this.setSelectionIndicatorPosition(position[0], position[1]);
-    entity.sprite.sortOrder = this.yToIndex(targetYIndex) + entity.getSortOrderOffset();
 
     if (!shouldJumpDown) {
       const animName = 'walk' + this.getDirectionName(facing);
@@ -907,6 +906,14 @@ module.exports = class LevelView {
     } else {
       tween = this.playPlayerJumpDownVerticalAnimation(facing, position, oldPosition);
     }
+
+    // Update the sort order halfway through the animation
+    tween.onUpdateCallback((tween, percent) => {
+      if (percent >= 0.5) {
+        entity.sprite.sortOrder = this.yToIndex(targetYIndex) + entity.getSortOrderOffset();
+        tween.onUpdateCallback(null);
+      }
+    });
 
     tween.onComplete.add(() => {
       completionHandler();

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -907,9 +907,9 @@ module.exports = class LevelView {
       tween = this.playPlayerJumpDownVerticalAnimation(facing, position, oldPosition);
     }
 
-    // Update the sort order halfway through the animation
+    // Update the sort order 3/4 of the way through the animation
     tween.onUpdateCallback((tween, percent) => {
-      if (percent >= 0.5) {
+      if (percent >= 0.75) {
         entity.sprite.sortOrder = this.yToIndex(targetYIndex) + entity.getSortOrderOffset();
         tween.onUpdateCallback(null);
       }

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -866,35 +866,30 @@ module.exports = class LevelView {
     }
   }
 
+  /**
+   * Play the MoveForward animation for the given entity. Note that both
+   * MoveForward and MoveBackward are implemented using the same walk
+   * animations, and the only difference between the two is the logic they use
+   * for moving north after placing a block
+   *
+   * @see LevelView.playWalkAnimation
+   */
   playMoveForwardAnimation(entity, oldPosition, facing, shouldJumpDown, isOnBlock, groundType, completionHandler) {
-    let tween;
-    let position = entity.position;
-
-    //stepping on stone sfx
-    this.playBlockSound(groundType);
-
-    this.setSelectionIndicatorPosition(position[0], position[1]);
-    //make sure to render high for when moving up after placing a block
-    var zOrderYIndex = position[1] + (facing === FacingDirection.North ? 1 : 0);
-    entity.sprite.sortOrder = this.yToIndex(zOrderYIndex) + entity.getSortOrderOffset();
-
-    if (!shouldJumpDown) {
-      const animName = "walk" + this.getDirectionName(facing);
-      this.playScaledSpeed(entity.sprite.animations, animName);
-      tween = this.addResettableTween(entity.sprite).to(
-        this.positionToScreen(position, isOnBlock, entity), 180, Phaser.Easing.Linear.None);
-    } else {
-      tween = this.playPlayerJumpDownVerticalAnimation(facing, position, oldPosition);
-    }
-
-    tween.onComplete.add(() => {
-      completionHandler();
-    });
-
-    tween.start();
+    // make sure to render high for when moving north after placing a block
+    const targetYIndex = entity.position[1] + (facing === FacingDirection.North ? 1 : 0);
+    this.playWalkAnimation(entity, oldPosition, facing, shouldJumpDown, isOnBlock, groundType, targetYIndex, completionHandler);
   }
 
-  playMoveBackwardAnimation(entity, oldPosition, facing, shouldJumpDown, isOnBlock, groundType, animation, completionHandler) {
+  /**
+   * @see LevelView.playMoveForwardAnimation
+   */
+  playMoveBackwardAnimation(entity, oldPosition, facing, shouldJumpDown, isOnBlock, groundType, completionHandler) {
+    // make sure to render high for when moving north after placing a block
+    const targetYIndex = entity.position[1] + (facing === FacingDirection.South ? 1 : 0);
+    this.playWalkAnimation(entity, oldPosition, facing, shouldJumpDown, isOnBlock, groundType, targetYIndex, completionHandler);
+  }
+
+  playWalkAnimation(entity, oldPosition, facing, shouldJumpDown, isOnBlock, groundType, targetYIndex, completionHandler) {
     let tween;
     let position = entity.position;
 
@@ -902,12 +897,10 @@ module.exports = class LevelView {
     this.playBlockSound(groundType);
 
     this.setSelectionIndicatorPosition(position[0], position[1]);
-    //make sure to render high for when moving up after placing a block
-    var zOrderYIndex = position[1] + (facing === FacingDirection.North ? 1 : 0);
-    entity.sprite.sortOrder = this.yToIndex(zOrderYIndex) + entity.getSortOrderOffset();
+    entity.sprite.sortOrder = this.yToIndex(targetYIndex) + entity.getSortOrderOffset();
 
     if (!shouldJumpDown) {
-      const animName = animation + this.getDirectionName(facing);
+      const animName = 'walk' + this.getDirectionName(facing);
       this.playScaledSpeed(entity.sprite.animations, animName);
       tween = this.addResettableTween(entity.sprite).to(
         this.positionToScreen(position, isOnBlock, entity), 180, Phaser.Easing.Linear.None);


### PR DESCRIPTION
[First](https://github.com/code-dot-org/craft/commit/8b52ea2aceae19688bf2e4ef1649dfc34cf90908), I update the `playMoveForwardAnimation` and `playMoveBackwardAnimation` methods to significantly reduce the amount of repeated code between them.

[Second](https://github.com/code-dot-org/craft/commit/94292a7f0b5089e61d2ee57360623a88438c86b2), I update the walk animation to actually hook into the tween and update the entity sortOrder at (approximately) the halfway point of the animation, rather than always updating it at the beginning. This means that the nice walking overlap effect happens for both entities in both directions, rather than before where it would only happen for the entity being drawn on the "bottom"

Entity | Before | After
--- | --- | ---
Agent | ![agent-before](https://user-images.githubusercontent.com/244100/31415959-15c0209c-addb-11e7-9762-c248b2bf645b.gif) | ![agent-after](https://user-images.githubusercontent.com/244100/31415852-bfafbeec-adda-11e7-8168-5217041d64ce.gif)
Player | ![player-before](https://user-images.githubusercontent.com/244100/31415963-186e3e0a-addb-11e7-8e9f-7041fda5b81a.gif) | ![player-after](https://user-images.githubusercontent.com/244100/31416038-7b3f5e1a-addb-11e7-8221-8b583730a429.gif)
