### PR TITLE
Add slight delay to Agent movement

### DIFF
--- a/src/js/game/Entities/Agent.js
+++ b/src/js/game/Entities/Agent.js
@@ -10,13 +10,8 @@ module.exports = class Agent extends BaseEntity {
     this.inventory = {};
     this.movementState = -1;
 
-    if (controller.getIsDirectPlayerControl()) {
-      this.moveDelayMin = 0;
-      this.moveDelayMax = 0;
-    } else {
-      this.moveDelayMin = 30;
-      this.moveDelayMax = 200;
-    }
+    this.moveDelayMin = 20;
+    this.moveDelayMax = 150;
   }
 
   /**


### PR DESCRIPTION
The player has a slight delay when in block-movement mode; because when
in arrow-movement mode the delay is handled by the arrows, we don't
impose an additional delay.

Because the agent was derived from player code, it was erroneously
giving itself no delay when the _player_ was in arrow mode.

Re-added the delay, independent of the state. Also gave it a delay of
about 2/3 that of the player to represent the fact that the agent should
still be moving slightly faster

Before

![before](https://user-images.githubusercontent.com/244100/31417012-ce4bfe5a-ade1-11e7-99ae-74ecefaaa7e6.gif)

After

![after](https://user-images.githubusercontent.com/244100/31417011-ce353be8-ade1-11e7-89d0-f5681e0f11ae.gif)