### PR TITLE
sticky pistons won't grab the wrong objects now

### DIFF
--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -26,6 +26,7 @@ module.exports = class LevelBlock {
     this.isRail = false;
     this.isSolid = true;
     this.isWeaklyPowerable = true;
+    this.isStickable = true;
 
     if (blockType === "") {
       this.isWalkable = true;
@@ -47,10 +48,12 @@ module.exports = class LevelBlock {
     if (blockType.match('torch')) {
       this.isWalkable = true;
       this.isPlacable = true;
+      this.isStickable = false;
     }
 
     if (blockType.substring(0, 5) === "rails") {
       this.isWeaklyPowerable = blockType === 'railsRedstoneTorch' ? true : false;
+      this.isStickable = blockType === 'railsRedstoneTorch' ? false : true;
       this.isEntity = true;
       this.isWalkable = true;
       this.isUsable = true;
@@ -130,6 +133,7 @@ module.exports = class LevelBlock {
       this.isUsable = true;
       this.isDestroyable = false;
       this.isTransparent = true;
+      this.isStickable = false;
     }
 
     if (blockType === "doorIron") {
@@ -140,6 +144,7 @@ module.exports = class LevelBlock {
       this.isDestroyable = false;
       this.isTransparent = true;
       this.isConnectedToRedstone = true;
+      this.isStickable = false;
     }
 
     if (blockType.startsWith("redstoneWire")) {
@@ -149,6 +154,7 @@ module.exports = class LevelBlock {
       this.isDestroyable = true;
       this.isTransparent = true;
       this.isRedstone = true;
+      this.isStickable = false;
     }
 
     if (blockType.startsWith("pressurePlate")) {
@@ -159,6 +165,7 @@ module.exports = class LevelBlock {
       this.isTransparent = true;
       this.isConnectedToRedstone = true;
       this.isRedstoneBattery = blockType === 'pressurePlateUp' ? false : true;
+      this.isStickable = false;
     }
 
     if (blockType === "glowstone") {

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -575,7 +575,7 @@ module.exports = class LevelPlane {
             stuckBlockPosition[0] += 1;
             break;
         }
-        if (this.inBounds(stuckBlockPosition)) {
+        if (this.inBounds(stuckBlockPosition) && this.getBlockAt(stuckBlockPosition).isStickable) {
           this.setBlockAt(armPosition, this.getBlockAt(stuckBlockPosition));
           this.setBlockAt(stuckBlockPosition, emptyBlock);
         } else {

--- a/test/unit/LevelPlaneTest.js
+++ b/test/unit/LevelPlaneTest.js
@@ -845,3 +845,63 @@ test('certain objets arent weakly charged', t => {
 
   t.end();
 });
+
+test('Sticky piston grabbing, do not pull', t => {
+  const data = [
+    '','','','','','','','',
+    '','','','','','','','',
+    'pressurePlateUp','','railsRedstoneTorch','','torch','','redstoneWire','',
+    'pistonArmUp','','pistonArmUp','','pistonArmUp','','pistonArmUp','',
+    'pistonUpOnSticky','','pistonUpOnSticky','','pistonUpOnSticky','','pistonUpOnSticky','',
+    'railsRedstoneTorch','','railsRedstoneTorch','','railsRedstoneTorch','','railsRedstoneTorch','',
+  ];
+  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+
+  plane.setBlockAt([0, 5], new LevelBlock(''));
+  plane.setBlockAt([2, 5], new LevelBlock(''));
+  plane.setBlockAt([4, 5], new LevelBlock(''));
+  plane.setBlockAt([6, 5], new LevelBlock(''));
+
+  const expected = [
+    '','','','','','','','',
+    '','','','','','','','',
+    'pressurePlateUp','','railsRedstoneTorch','','torch','','redstoneWire','',
+    '','','','','','','','',
+    'pistonUpSticky','','pistonUpSticky','','pistonUpSticky','','pistonUpSticky','',
+    '','','','','','','','',
+  ];
+
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
+
+  t.end();
+});
+
+test('Sticky piston grabbing, do pull', t => {
+  const data = [
+    '','','','','','','','',
+    '','','','','','','','',
+    'grass','','bedrock','','railsSouth','','netherrack','',
+    'pistonArmUp','','pistonArmUp','','pistonArmUp','','pistonArmUp','',
+    'pistonUpOnSticky','','pistonUpOnSticky','','pistonUpOnSticky','','pistonUpOnSticky','',
+    'railsRedstoneTorch','','railsRedstoneTorch','','railsRedstoneTorch','','railsRedstoneTorch','',
+  ];
+  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+
+  plane.setBlockAt([0, 5], new LevelBlock(''));
+  plane.setBlockAt([2, 5], new LevelBlock(''));
+  plane.setBlockAt([4, 5], new LevelBlock(''));
+  plane.setBlockAt([6, 5], new LevelBlock(''));
+
+  const expected = [
+    '','','','','','','','',
+    '','','','','','','','',
+    '','','','','','','','',
+    'grass','','bedrock','','railsSouth','','netherrack','',
+    'pistonUpSticky','','pistonUpSticky','','pistonUpSticky','','pistonUpSticky','',
+    '','','','','','','','',
+  ];
+
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
+
+  t.end();
+});


### PR DESCRIPTION
@joshlory @Hamms 

This is a fix for [issue#265](https://github.com/code-dot-org/craft/issues/265)