### PR TITLE
Correct piston sort order for blocks in the level config

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1005,8 +1005,10 @@ module.exports = class LevelView {
     });
   }
 
-  correctForShadowOverlay(blockType) {
-    return blockType.startsWith("pistonArm");
+  correctForShadowOverlay(blockType, sprite) {
+    if (blockType.startsWith("piston")) {
+      sprite.sortOrder -= 0.1;
+    }
   }
 
   createActionPlaneBlock(position, blockType) {
@@ -1019,11 +1021,8 @@ module.exports = class LevelView {
     var sprite = this.createBlock(this.actionPlane, position[0], position[1], blockType);
 
     if (sprite) {
-      let correction = 0;
-      if (this.correctForShadowOverlay(blockType)) {
-        correction = -0.1;
-      }
-      sprite.sortOrder = this.yToIndex(position[1]) + correction;
+      sprite.sortOrder = this.yToIndex(position[1]);
+      this.correctForShadowOverlay(blockType, sprite);
     }
 
     this.actionPlaneBlocks[blockIndex] = sprite;
@@ -1388,6 +1387,7 @@ module.exports = class LevelView {
 
           if (sprite !== null) {
             sprite.sortOrder = this.yToIndex(y);
+            this.correctForShadowOverlay(actionBlock.blockType, sprite);
           }
         }
 


### PR DESCRIPTION
Partial fix for https://github.com/code-dot-org/craft/issues/164#issuecomment-335968741.  Currently we only correct piston sort order for newly-placed blocks.  Also correct piston sort order for blocks in the level config.

Before:

![image](https://user-images.githubusercontent.com/413693/31514790-afe98542-af47-11e7-9bd7-203a5761a977.png)

After:

![image](https://user-images.githubusercontent.com/413693/31514769-a05dc412-af47-11e7-8616-8ea18373df9b.png)