### PR TITLE
Render "flat" blocks in Ground Plane

### DIFF
--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -190,9 +190,25 @@ module.exports = class LevelBlock {
     }
   }
 
+  /**
+   * "flat" blocks are those subset of walkable blocks which are walkable
+   * because they are lying right on the ground, as opposed to those blocks like
+   * torches which are walkable because they do not occupy very much space.
+   */
+  isFlat() {
+    return this.blockType.substring(0, 5) === "rails" ||
+        this.blockType.startsWith("redstoneWire") ||
+        this.blockType.startsWith("pressurePlate");
+  }
+
+  shouldRenderOnGroundPlane() {
+    return this.isFlat();
+  }
+
   getIsStickyPiston() {
     return this.blockType.substring(this.blockType.length - 6, this.blockType.length) === "Sticky";
   }
+
   canHoldCharge() {
     return this.isSolid;
   }


### PR DESCRIPTION
Blocks that conceptually lie flat on the ground have up til this point not been able to receive shadows from other blocks nor from the ShadeLayer that applies to all ground blocks. Now they can!

![image](https://user-images.githubusercontent.com/244100/31524897-6fbbf746-af71-11e7-965c-3e90c9171b10.png)
![image](https://user-images.githubusercontent.com/244100/31524909-7e30907a-af71-11e7-9781-82b6c375e3cb.png)

Specifically, blocks now have an internal concept of whether or not they are "flat", and whether or not they should be rendered on the ground layer. LevelView also now supports paying attention to this, and rendering Action blocks on either the action or ground layer.

Note that we have both a LevelModel.actionPlane and a LevelView.actionPlane, which are two different things, and this PR makes that even more confusing. I plan to (in a separate PR) rename LevelView.actionPlane to LevelView.actionGroup to help reduce this confusion.