### PR TITLE
Add some visual variance to the Action Plane, to match Shade_Layer.png

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -2061,8 +2061,9 @@ module.exports = class LevelView {
         yOffset = this.blocks[blockType][3];
         sprite = plane.create(xOffset + 40 * x, yOffset + plane.yOffset + 40 * y, atlas, frame);
         if (plane === this.actionPlane) {
+          const psuedoRandom = x * 97 + y * 29;
           const variance = 0x12;
-          const brightness = (Math.round(Math.random() * variance) + 0xff - variance).toString(16);
+          const brightness = ((psuedoRandom % variance) + 0xff - variance).toString(16);
           sprite.tint = '0x' + brightness + brightness + brightness;
         }
         break;

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -2060,6 +2060,11 @@ module.exports = class LevelView {
         xOffset = this.blocks[blockType][2];
         yOffset = this.blocks[blockType][3];
         sprite = plane.create(xOffset + 40 * x, yOffset + plane.yOffset + 40 * y, atlas, frame);
+        if (plane === this.actionPlane) {
+          const variance = 0x12;
+          const brightness = (Math.round(Math.random() * variance) + 0xff - variance).toString(16);
+          sprite.tint = '0x' + brightness + brightness + brightness;
+        }
         break;
     }
 


### PR DESCRIPTION
The Ground Plane uses ["Shade_Layer.png"](https://github.com/code-dot-org/craft/blob/b7a639891326a1a054280e865de5501353cda91a/src/assets/images/Shade_Layer.png) to provide some visual variation and make the grid square visible.  Add similar variation to the Action Plane.

Before:

![image](https://user-images.githubusercontent.com/413693/31525117-e0fd6f42-af72-11e7-8347-abd67be4d0fe.png)

After:

![image](https://user-images.githubusercontent.com/413693/31525120-e7035618-af72-11e7-8b55-cffcdeee6322.png)
