### PR TITLE
woooops. We weren't checking bounds for off-map-block-pushing

### DIFF
--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -612,7 +612,9 @@ module.exports = class LevelPlane {
         }
         redo = true;
       }
-      this.setBlockAt(destination, this.getBlockAt(blocksPositions[i]));
+      if (this.inBounds(destination)) {
+        this.setBlockAt(destination, this.getBlockAt(blocksPositions[i]));
+      }
       if (i === 0) {
         this.setBlockAt(blocksPositions[i], armBlock);
       }

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -129,6 +129,9 @@ module.exports = class LevelPlane {
   * Important note: This is the cornerstone of block placing/destroying.
   */
   setBlockAt(position, block) {
+    if (!this.inBounds(position)) {
+      return;
+    }
     this._data[this.coordinatesToIndex(position)] = block;
 
     if (this.isActionPlane()) {
@@ -612,9 +615,7 @@ module.exports = class LevelPlane {
         }
         redo = true;
       }
-      if (this.inBounds(destination)) {
-        this.setBlockAt(destination, this.getBlockAt(blocksPositions[i]));
-      }
+      this.setBlockAt(destination, this.getBlockAt(blocksPositions[i]));
       if (i === 0) {
         this.setBlockAt(blocksPositions[i], armBlock);
       }


### PR DESCRIPTION
@joshlory or @Hamms 

Goofed and didn't check bounds. setBlockAt() calls coordinatesToIndex() which assumes everything is in bounds, and it ends up wrapping: [-1, 3] is interpreted as [9, 2] (because y * width + x, if x is -1 you just end up with 30 - 1 = 29)

Completely happenstance that it wrapped perfectly to the row above. This was breaking the diamond path in level 5, but should be fine now.

Resolves https://github.com/code-dot-org/craft/issues/288.