### PR TITLE
Fix ground group refresh bug

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1014,14 +1014,15 @@ module.exports = class LevelView {
   createActionPlaneBlock(position, blockType) {
     const block = new LevelBlock(blockType);
     const blockIndex = (this.yToIndex(position[1])) + position[0];
-    if (block.isEmpty) {
-      this.actionPlaneBlocks[blockIndex] = null;
-      return;
-    }
 
     // Remove the old sprite at this position, if there is one.
     this.actionGroup.remove(this.actionPlaneBlocks[blockIndex]);
     this.groundGroup.remove(this.actionPlaneBlocks[blockIndex]);
+
+    if (block.isEmpty) {
+      this.actionPlaneBlocks[blockIndex] = null;
+      return;
+    }
 
     // Create a new sprite.
     let sprite;

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1373,9 +1373,9 @@ module.exports = class LevelView {
       }
     }
 
+    this.actionPlaneBlocks = [];
     this.refreshGroundGroup();
 
-    this.actionPlaneBlocks = [];
     for (y = 0; y < this.controller.levelModel.planeHeight; ++y) {
       for (x = 0; x < this.controller.levelModel.planeWidth; ++x) {
         let position = [x, y];


### PR DESCRIPTION
Because `refreshGroundGroup` is now partially responsible for populating LevelView's `actionPlaneBlocks` array, when refreshing the action group we don't want to reset `actionPlaneBlocks` until after refreshing the ground group. And because blocks are no longer added to the array strictly in order (because we add all ground blocks first in the `refreshGroundGroup` method before going in and adding the action blocks), it no longer makes sense to use `.push` to update the array.

And finally, since we're no longer using `.push`, the creation of the blocks that happens in `refreshGroups` is now practically identical to the creation of blocks that happens in the `createActionPlaneBlock` helper method, so just use that instead of any custom logic.