### PR TITLE
Redstone destroy fixes

### DIFF
--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -191,14 +191,11 @@ module.exports = class LevelBlock {
   }
 
   /**
-   * "flat" blocks are those subset of walkable blocks which are walkable
-   * because they are lying right on the ground, as opposed to those blocks like
-   * torches which are walkable because they do not occupy very much space.
+   * @see {LevelBlock.isFlat}
+   * @return {boolean}
    */
   isFlat() {
-    return this.blockType.substring(0, 5) === "rails" ||
-        this.blockType.startsWith("redstoneWire") ||
-        this.blockType.startsWith("pressurePlate");
+    return LevelBlock.isFlat(this.blockType);
   }
 
   shouldRenderOnGroundPlane() {
@@ -214,6 +211,7 @@ module.exports = class LevelBlock {
   }
 
   /**
+   * @see {LevelBlock.isMiniblock}
    * @return {boolean}
    */
   getIsMiniblock() {
@@ -295,6 +293,21 @@ module.exports = class LevelBlock {
    */
   static isMiniblock(blockType) {
     return blockType.endsWith("Miniblock");
+  }
+
+  /**
+   * Does the given block type represent a "flat" block?
+   * "flat" blocks are those subset of walkable blocks which are walkable
+   * because they are lying right on the ground, as opposed to those blocks like
+   * torches which are walkable because they do not occupy very much space.
+   *
+   * @param {String} blockType
+   * @return {boolean}
+   */
+  static isFlat(blockType) {
+    return blockType.substring(0, 5) === "rails" ||
+        blockType.startsWith("redstoneWire") ||
+        blockType.startsWith("pressurePlate");
   }
 
   /**

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1252,6 +1252,36 @@ module.exports = class LevelView {
         explodeAnim.tint = 0x8a5e33;
         break;
 
+      case "redstoneWireOn":
+      case "redstoneWireHorizontalOn":
+      case "redstoneWireVerticalOn":
+      case "redstoneWireUpRightOn":
+      case "redstoneWireUpLeftOn":
+      case "redstoneWireDownRightOn":
+      case "redstoneWireDownLeftOn":
+      case "redstoneWireTUpOn":
+      case "redstoneWireTDownOn":
+      case "redstoneWireTLeftOn":
+      case "redstoneWireTRightOn":
+      case "redstoneWireCrossOn":
+        explodeAnim.tint = 0x990707;
+        break;
+
+      case "redstoneWire":
+      case "redstoneWireHorizontal":
+      case "redstoneWireVertical":
+      case "redstoneWireUpRight":
+      case "redstoneWireUpLeft":
+      case "redstoneWireDownRight":
+      case "redstoneWireDownLeft":
+      case "redstoneWireTUp":
+      case "redstoneWireTDown":
+      case "redstoneWireTLeft":
+      case "redstoneWireTRight":
+      case "redstoneWireCross":
+        explodeAnim.tint = 0x290202;
+        break;
+
       default:
         break;
     }


### PR DESCRIPTION
Updates redstone (and rails) to no longer erroneously display the cube-shaped destroy overlay animation upon destroy, and to instead just immediately explode with no animation.

Also update the color of the redstone explosion animation to be dark or bright red depending on whether or not it was powered.

![redstone](https://user-images.githubusercontent.com/244100/31571024-67810dc6-b040-11e7-953f-b05a5ef7baa7.gif)

Fixes https://github.com/code-dot-org/craft/issues/80
