### PR TITLE
iron doors no longer set player animation to idle

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -2146,7 +2146,10 @@ module.exports = class LevelView {
     this.playDoorAnimation(position, open, () => {
       const block = this.controller.levelModel.actionPlane.getBlockAt(position);
       block.isWalkable = !block.isWalkable;
-      this.playIdleAnimation(player.position, player.facing, player.isOnBlock, player);
+      if (block.blockType !== "doorIron") {
+        // Iron doors don't need to set the player animation to Idle, because they're not opened with 'use'.
+        this.playIdleAnimation(player.position, player.facing, player.isOnBlock, player);
+      }
       this.setSelectionIndicatorPosition(player.position[0], player.position[1]);
     });
   }


### PR DESCRIPTION
fixes issue: [#209](https://github.com/code-dot-org/craft/issues/209)