### PR TITLE
Save correct miniblock offset

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1858,10 +1858,10 @@ module.exports = class LevelView {
     const frameStart = this.miniBlocks[frame][1];
     const frameEnd = this.miniBlocks[frame][2];
     const xOffset = -10 - (xOffsetRange / 2) + (Math.random() * xOffsetRange);
-    const yOffset = 0 - (yOffsetRange / 2) + (Math.random() * yOffsetRange);
+    const yOffset = 0 - (yOffsetRange / 2) + (Math.random() * yOffsetRange) + this.actionGroup.yOffset;
 
     frameList = Phaser.Animation.generateFrameNames(framePrefix, frameStart, frameEnd, ".png", 3);
-    sprite = this.actionGroup.create(xOffset + 40 * x, yOffset + this.actionGroup.yOffset + 40 * y, atlas, "");
+    sprite = this.actionGroup.create(xOffset + 40 * x, yOffset + 40 * y, atlas, "");
     const anim = sprite.animations.add("animate", frameList, 10, false);
 
     if (this.controller.getIsDirectPlayerControl()) {


### PR DESCRIPTION
Collectible minblocks were rendering with the actionGroup yOffset being
taken into account, but were not including that offset when saving
themselves to collectibleItems, meaning that the distance calculations
ultimately being used to determine whether or not the player is close
enough to pick them up were off by just that much.

Fixes #319