### PR TITLE
Add `levelView.drawHintPath` API for more specific in-game hints

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1396,6 +1396,8 @@ module.exports = class LevelView {
    * @param {Array<Array<int>>} gridSpaces An array of x and y grid coordinates.
    */
   drawHintPath(gridSpaces) {
+    this.hintGroup.removeAll(true);
+
     const hintPath = this.game.add.bitmapData(400, 400);
     this.hintGroup.create(0, 0, hintPath);
 

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1398,7 +1398,8 @@ module.exports = class LevelView {
   drawHintPath(gridSpaces) {
     this.hintGroup.removeAll(true);
 
-    const hintPath = this.game.add.bitmapData(400, 400);
+    const bounds = this.game.world.bounds;
+    const hintPath = this.game.add.bitmapData(bounds.width, bounds.height);
     const sprite = this.hintGroup.create(0, 0, hintPath);
     sprite.alpha = 0;
 

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1392,11 +1392,37 @@ module.exports = class LevelView {
     this.selectionIndicator.y = -55 + 43 + 40 * y;
   }
 
+  /**
+   * @param {Array<Array<int>>} gridSpaces An array of x and y grid coordinates.
+   */
+  drawHintPath(gridSpaces) {
+    const hintPath = this.game.add.bitmapData(400, 400);
+    this.hintGroup.create(0, 0, hintPath);
+
+    const context = hintPath.context;
+    context.setLineDash([10, 10]);
+    context.lineDashOffset = 5;
+    context.lineWidth = 2;
+    context.strokeStyle = '#fff';
+    context.shadowColor = '#000';
+    context.shadowOffsetY = 7;
+    context.shadowBlur = 4;
+
+    context.beginPath();
+    gridSpaces.forEach(([x, y]) => {
+      context.lineTo(40 * x + 19, 40 * y + 19);
+    });
+    context.stroke();
+
+    hintPath.dirty = true;
+  }
+
   createGroups() {
     this.groundGroup = this.game.add.group();
     this.groundGroup.yOffset = -2;
     this.shadingGroup = this.game.add.group();
     this.shadingGroup.yOffset = -2;
+    this.hintGroup = this.game.add.group();
     this.actionGroup = this.game.add.group();
     this.actionGroup.yOffset = -22;
     this.fluffGroup = this.game.add.group();
@@ -1412,6 +1438,7 @@ module.exports = class LevelView {
 
     this.groundGroup.removeAll(true);
     this.actionGroup.removeAll(true);
+    this.hintGroup.removeAll(true);
     this.fluffGroup.removeAll(true);
     this.shadingGroup.removeAll(true);
     this.fowGroup.removeAll(true);

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1400,12 +1400,6 @@ module.exports = class LevelView {
 
     const bounds = this.game.world.bounds;
     const hintPath = this.game.add.bitmapData(bounds.width, bounds.height);
-    const sprite = this.hintGroup.create(0, 0, hintPath);
-    sprite.alpha = 0;
-
-    this.addResettableTween(sprite)
-      .to({alpha: 1}, 830, Phaser.Easing.Quadratic.Out)
-      .to({alpha: 0.4}, 500, Phaser.Easing.Quadratic.InOut, true, 0, -1, true);
 
     const context = hintPath.context;
     context.setLineDash([10, 10]);
@@ -1422,7 +1416,12 @@ module.exports = class LevelView {
     });
     context.stroke();
 
-    hintPath.dirty = true;
+    const sprite = this.hintGroup.create(0, 0, hintPath);
+    sprite.alpha = 0;
+
+    this.addResettableTween(sprite)
+      .to({alpha: 1}, 830, Phaser.Easing.Quadratic.Out)
+      .to({alpha: 0.4}, 500, Phaser.Easing.Quadratic.InOut, true, 0, -1, true);
   }
 
   createGroups() {

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1399,7 +1399,12 @@ module.exports = class LevelView {
     this.hintGroup.removeAll(true);
 
     const hintPath = this.game.add.bitmapData(400, 400);
-    this.hintGroup.create(0, 0, hintPath);
+    const sprite = this.hintGroup.create(0, 0, hintPath);
+    sprite.alpha = 0;
+
+    this.addResettableTween(sprite)
+      .to({alpha: 1}, 830, Phaser.Easing.Quadratic.Out)
+      .to({alpha: 0.4}, 500, Phaser.Easing.Quadratic.InOut, true, 0, -1, true);
 
     const context = hintPath.context;
     context.setLineDash([10, 10]);


### PR DESCRIPTION
Resolves https://github.com/code-dot-org/craft/issues/321.  Sample usage:

```js
gameController.levelView.drawHintPath([[5, 9], [5, 7], [6, 7], [6, 5]]);
```

![screen shot 2017-10-17 at 3 09 36 pm](https://user-images.githubusercontent.com/413693/31692244-df110b1a-b34d-11e7-8f0d-8591bb938380.png)