### PR TITLE
can not put pressure plates on land but not in water/lava

### DIFF
--- a/src/js/game/Entities/Agent.js
+++ b/src/js/game/Entities/Agent.js
@@ -25,9 +25,7 @@ module.exports = class Agent extends BaseEntity {
         result.plane = "groundPlane";
       }
     } else {
-      if (toPlaceBlock.isRedstone ||
-      toPlaceBlock.isRail ||
-      toPlaceBlock.blockType === "pressurePlateUp") {
+      if (toPlaceBlock.isFlat() ) {
         result.canPlace = true;
         result.plane = "actionPlane";
       }

--- a/src/js/game/Entities/Agent.js
+++ b/src/js/game/Entities/Agent.js
@@ -25,7 +25,9 @@ module.exports = class Agent extends BaseEntity {
         result.plane = "groundPlane";
       }
     } else {
-      if (toPlaceBlock.isRedstone || toPlaceBlock.isRail) {
+      if (toPlaceBlock.isRedstone ||
+      toPlaceBlock.isRail ||
+      toPlaceBlock.blockType === "pressurePlateUp") {
         result.canPlace = true;
         result.plane = "actionPlane";
       }

--- a/src/js/game/Entities/Agent.js
+++ b/src/js/game/Entities/Agent.js
@@ -25,7 +25,7 @@ module.exports = class Agent extends BaseEntity {
         result.plane = "groundPlane";
       }
     } else {
-      if (toPlaceBlock.isFlat() ) {
+      if (toPlaceBlock.isWalkable) {
         result.canPlace = true;
         result.plane = "actionPlane";
       }

--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -244,7 +244,8 @@ module.exports = class LevelBlock {
       this.getIsPiston() ||
       this.isRail ||
       this.blockType === 'torch' ||
-      this.blockType === 'railsRedstoneTorch';
+      this.blockType === 'railsRedstoneTorch' ||
+      this.blockType === 'pressurePlateUp';
 
     return !notPlaceable;
   }

--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -326,7 +326,8 @@ module.exports = class LevelBlock {
   static isFlat(blockType) {
     return blockType.substring(0, 5) === "rails" ||
         blockType.startsWith("redstoneWire") ||
-        blockType.startsWith("pressurePlate");
+        blockType.startsWith("pressurePlate") ||
+        blockType === "torch";
   }
 
   /**

--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -324,7 +324,8 @@ module.exports = class LevelBlock {
    * @return {boolean}
    */
   static isFlat(blockType) {
-    return blockType.substring(0, 5) === "rails" ||
+    // Starts With 'rail' will capture rails and railsRedstoneTorch.
+    return blockType.isRail ||
         blockType.startsWith("redstoneWire") ||
         blockType.startsWith("pressurePlate") ||
         blockType === "torch";

--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -327,8 +327,7 @@ module.exports = class LevelBlock {
     // Starts With 'rail' will capture rails and railsRedstoneTorch.
     return blockType.isRail ||
         blockType.startsWith("redstoneWire") ||
-        blockType.startsWith("pressurePlate") ||
-        blockType === "torch";
+        blockType.startsWith("pressurePlate");
   }
 
   /**


### PR DESCRIPTION
@joshlory PTAL

This fixes [issue:318](https://github.com/code-dot-org/craft/issues/318)

pressurePlates should be fine to place on land (and therefore on the action Plane) but NOT over water, thus in the ground plane, thus allowing the player to put redstoneWire over top of them. 

What a silly mistake 😥 