### PR TITLE
When rail blocks are removed, sever the connections from adjacent rail blocks

### DIFF
--- a/src/js/game/LevelMVC/FacingDirection.js
+++ b/src/js/game/LevelMVC/FacingDirection.js
@@ -25,6 +25,15 @@ const FacingDirection = Object.freeze({
   turn: function (facing, rotation) {
     return (facing + 4 + (rotation === 'right' ? 1 : -1)) % 4;
   },
+
+  directionToOffset(direction) {
+    switch (direction) {
+      case FacingDirection.North: return [0, -1];
+      case FacingDirection.South: return [0, 1];
+      case FacingDirection.East: return [1, 0];
+      case FacingDirection.West: return [-1, 0];
+    }
+  }
 });
 
 module.exports = FacingDirection;

--- a/test/unit/LevelPlaneTest.js
+++ b/test/unit/LevelPlaneTest.js
@@ -295,6 +295,44 @@ test('rail connections: destroy block', t => {
   t.end();
 });
 
+// Placing track after a previously-destroyed T-junction should heal it
+//
+// Before:   After:
+//              ║
+//   ═╗         ║
+//    ║         ║
+test('rail connections: destroy block', t => {
+  const data = new Array(9).fill('');
+  const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
+
+  plane.setBlockAt([1, 2], new LevelBlock('rails'));
+  plane.setBlockAt([1, 1], new LevelBlock('rails'));
+  plane.setBlockAt([0, 1], new LevelBlock('rails'));
+
+  // Destroy track block.
+  plane.setBlockAt([0, 1], new LevelBlock(''));
+
+  let expected = [
+    '', '','',
+    '', 'railsSouthWest', '',
+    '', 'railsNorth','',
+  ];
+
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
+
+  plane.setBlockAt([1, 0], new LevelBlock('rails'));
+
+  expected = [
+    '', 'railsSouth','',
+    '', 'railsNorthSouth', '',
+    '', 'railsNorth','',
+  ];
+
+  t.deepEqual(plane._data.map(block => block.blockType), expected);
+
+  t.end();
+});
+
 //Placing/destroying redstoneWire should update charge propagation throughout
 //a line of wire connected to a redstone torch
 // Before:   After:


### PR DESCRIPTION
This allows for newly placed rail blocks to "heal" rails whose
connections were removed, while still not updating rails that are
already happily connected

Fixes https://github.com/code-dot-org/craft/issues/105