### PR TITLE
if on an agent level, 'use' command simply exits out

### DIFF
--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -990,6 +990,10 @@ class GameController {
   }
 
   use(commandQueueItem) {
+    if (this.levelData.isAgentLevel) {
+      commandQueueItem.succeeded();
+      return;
+    }
     let player = this.levelModel.player;
     let frontPosition = this.levelModel.getMoveForwardPosition(player);
     let frontEntity = this.levelEntity.getEntityAt(frontPosition);


### PR DESCRIPTION
@joshlory 

if we're in an agent level, the 'use' command should be exited out of. This feature was requested this morning as the direction people want to go with in regards to that functionality.