### PR TITLE
Ghast sprite sort order set to max, so it always draws on top

### DIFF
--- a/src/js/game/Entities/Ghast.js
+++ b/src/js/game/Entities/Ghast.js
@@ -2,10 +2,9 @@ const BaseEntity = require("./BaseEntity.js");
 module.exports = class Ghast extends BaseEntity {
     constructor(controller, type, identifier, x, y, facing) {
         super(controller, type, identifier, x, y, facing);
-        var zOrderYIndex = this.position[1];
         this.offset = [-50, -84];
         this.prepareSprite();
-        this.sprite.sortOrder = this.controller.levelView.yToIndex(zOrderYIndex);
+        this.sprite.sortOrder = this.controller.levelView.yToIndex(Number.MAX_SAFE_INTEGER);
     }
 
     prepareSprite() {
@@ -55,6 +54,13 @@ module.exports = class Ghast extends BaseEntity {
         this.sprite.x = this.offset[0] + 40 * this.position[0];
         this.sprite.y = this.offset[1] + 40 * this.position[1];
     }
+
+  /**
+   * @override
+   */
+  canMoveThrough() {
+    return true;
+  }
 
     playRandomIdle(facing) {
         var facingName,


### PR DESCRIPTION
@joshlory or @Hamms 

Per Cole and Joel, it has been decided that the best way to handle the Ghast, as it is a flying entity, is to simply have it draw on top of all other sprites and to allow the agent and steve to walk through it. 