### PR TITLE
First pass at refactoring redstone propagation

### DIFF
--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -39,11 +39,7 @@ module.exports = class LevelModel {
     this.shadingPlane = [];
     this.actionPlane = new LevelPlane(this.initialLevelData.actionPlane, this.planeWidth, this.planeHeight, this.controller, this, "actionPlane");
 
-    this.actionPlane.getAllPositions().forEach((position) => {
-      if (this.actionPlane.getBlockAt(position).isRedstoneBattery) {
-        this.actionPlane.redstonePropagation(position);
-      }
-    });
+    this.actionPlane.powerRedstone();
 
     this.actionPlane.getAllPositions().forEach((position) => {
       if (this.actionPlane.getBlockAt(position).isRedstone) {

--- a/test/unit/LevelPlaneTest.js
+++ b/test/unit/LevelPlaneTest.js
@@ -341,7 +341,7 @@ test('powered rails: vertical charge propagation', t => {
   ];
   const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
 
-  plane.getRedstone();
+  plane.refreshRedstone();
   t.equal(plane.getBlockAt([1, 1]).blockType, "railsPoweredSouth");
   t.equal(plane.getBlockAt([1, 2]).blockType, "railsPoweredNorth");
 
@@ -356,7 +356,7 @@ test('powered rails: horizontal charge propagation', t => {
   ];
   const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
 
-  plane.getRedstone();
+  plane.refreshRedstone();
   t.equal(plane.getBlockAt([1, 1]).blockType, "railsPoweredEast");
   t.equal(plane.getBlockAt([2, 1]).blockType, "railsPoweredWest");
 


### PR DESCRIPTION
Replace the old recursive approach to redstone propagation with one
using the new concept of adjacency sets.

Next step is to implement a more targeted refresh operation that only
touches blocks in the adjacency set of the thing being updated, rather
than the whole plane.