### PR TITLE
Bake AO offsets into the atlas JSON

### DIFF
--- a/src/assets/images/AO.json
+++ b/src/assets/images/AO.json
@@ -13,7 +13,7 @@
 	"frame": {"x":28,"y":14,"w":14,"h":14},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":1,"y":0,"w":14,"h":14},
+	"spriteSourceSize": {"x":26,"y":0,"w":14,"h":14},
 	"sourceSize": {"w":15,"h":15}
 },
 "AOeffect_BottomRight":
@@ -29,7 +29,7 @@
 	"frame": {"x":0,"y":0,"w":14,"h":40},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":1,"y":0,"w":14,"h":40},
+	"spriteSourceSize": {"x":26,"y":0,"w":14,"h":40},
 	"sourceSize": {"w":15,"h":40}
 },
 "AOeffect_Right":
@@ -45,7 +45,7 @@
 	"frame": {"x":28,"y":0,"w":40,"h":14},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":0,"y":1,"w":40,"h":14},
+	"spriteSourceSize": {"x":0,"y":26,"w":40,"h":14},
 	"sourceSize": {"w":40,"h":15}
 },
 "AOeffect_TopLeft":
@@ -53,7 +53,7 @@
 	"frame": {"x":42,"y":14,"w":14,"h":14},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":1,"y":1,"w":14,"h":14},
+	"spriteSourceSize": {"x":26,"y":26,"w":14,"h":14},
 	"sourceSize": {"w":15,"h":15}
 },
 "AOeffect_TopRight":
@@ -61,7 +61,7 @@
 	"frame": {"x":54,"y":28,"w":14,"h":14},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":0,"y":1,"w":14,"h":14},
+	"spriteSourceSize": {"x":0,"y":26,"w":14,"h":14},
 	"sourceSize": {"w":15,"h":15}
 }},
 "meta": {

--- a/src/assets/images/Block_Shadows.json
+++ b/src/assets/images/Block_Shadows.json
@@ -5,7 +5,7 @@
 	"frame": {"x":0,"y":0,"w":12,"h":50},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":52,"y":12,"w":12,"h":50},
+	"spriteSourceSize": {"x":0,"y":-10,"w":12,"h":50},
 	"sourceSize": {"w":64,"h":64}
 },
 "Shadow_Parts_Fade_overlap.png":
@@ -21,7 +21,7 @@
 	"frame": {"x":0,"y":70,"w":10,"h":10},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":52,"y":12,"w":10,"h":10},
+	"spriteSourceSize": {"x":0,"y":-10,"w":10,"h":10},
 	"sourceSize": {"w":64,"h":64}
 }},
 "meta": {

--- a/src/assets/images/LavaGlow.json
+++ b/src/assets/images/LavaGlow.json
@@ -5,7 +5,7 @@
 		"frame": {"x":0,"y":0,"w":12,"h":40},
 		"rotated": false,
 		"trimmed": true,
-		"spriteSourceSize": {"x":28,"y":22,"w":12,"h":40},
+		"spriteSourceSize": {"x":28,"y":0,"w":12,"h":40},
 		"sourceSize": {"w":64,"h":64},
 		"pivot": {"x":0.5,"y":0.5}
 	},
@@ -14,7 +14,7 @@
 		"frame": {"x":24,"y":16,"w":40,"h":8},
 		"rotated": false,
 		"trimmed": true,
-		"spriteSourceSize": {"x":0,"y":54,"w":40,"h":8},
+		"spriteSourceSize": {"x":0,"y":32,"w":40,"h":8},
 		"sourceSize": {"w":64,"h":64},
 		"pivot": {"x":0.5,"y":0.5}
 	},
@@ -23,7 +23,7 @@
 		"frame": {"x":48,"y":24,"w":10,"h":8},
 		"rotated": false,
 		"trimmed": true,
-		"spriteSourceSize": {"x":0,"y":54,"w":10,"h":8},
+		"spriteSourceSize": {"x":0,"y":32,"w":10,"h":8},
 		"sourceSize": {"w":64,"h":64},
 		"pivot": {"x":0.5,"y":0.5}
 	},
@@ -32,7 +32,7 @@
 		"frame": {"x":48,"y":32,"w":10,"h":8},
 		"rotated": false,
 		"trimmed": true,
-		"spriteSourceSize": {"x":30,"y":54,"w":10,"h":8},
+		"spriteSourceSize": {"x":30,"y":32,"w":10,"h":8},
 		"sourceSize": {"w":64,"h":64},
 		"pivot": {"x":0.5,"y":0.5}
 	},
@@ -41,7 +41,7 @@
 		"frame": {"x":24,"y":24,"w":12,"h":16},
 		"rotated": false,
 		"trimmed": true,
-		"spriteSourceSize": {"x":28,"y":22,"w":12,"h":16},
+		"spriteSourceSize": {"x":28,"y":0,"w":12,"h":16},
 		"sourceSize": {"w":64,"h":64},
 		"pivot": {"x":0.5,"y":0.5}
 	},
@@ -50,7 +50,7 @@
 		"frame": {"x":36,"y":24,"w":12,"h":16},
 		"rotated": false,
 		"trimmed": true,
-		"spriteSourceSize": {"x":0,"y":22,"w":12,"h":16},
+		"spriteSourceSize": {"x":0,"y":0,"w":12,"h":16},
 		"sourceSize": {"w":64,"h":64},
 		"pivot": {"x":0.5,"y":0.5}
 	},
@@ -59,7 +59,7 @@
 		"frame": {"x":12,"y":0,"w":12,"h":40},
 		"rotated": false,
 		"trimmed": true,
-		"spriteSourceSize": {"x":0,"y":22,"w":12,"h":40},
+		"spriteSourceSize": {"x":0,"y":0,"w":12,"h":40},
 		"sourceSize": {"w":64,"h":64},
 		"pivot": {"x":0.5,"y":0.5}
 	},
@@ -68,17 +68,17 @@
 		"frame": {"x":24,"y":0,"w":40,"h":16},
 		"rotated": false,
 		"trimmed": true,
-		"spriteSourceSize": {"x":0,"y":22,"w":40,"h":16},
+		"spriteSourceSize": {"x":0,"y":0,"w":40,"h":16},
 		"sourceSize": {"w":64,"h":64},
 		"pivot": {"x":0.5,"y":0.5}
 	}},
 	"meta": {
 		"app": "http://www.codeandweb.com/texturepacker",
 		"version": "1.0",
-		"image": "WaterAO.png",
+		"image": "LavaGlow.png",
 		"format": "RGBA8888",
 		"size": {"w":64,"h":40},
 		"scale": "1",
-		"smartupdate": "$TexturePacker:SmartUpdate:9c9b2d199a4ec9e95de28dd2d2060b34:09781ad36a4908d3eb07d2a1bdccc83b:dc4d5788172292d564bc29435a79fc5a$"
+		"smartupdate": "$TexturePacker:SmartUpdate:69ff8a7981887de66adc99f827bbba07:3e49797d4f2836b79c08e95ad346827f:f92ac7bd47fc2feff93215570390e83d$"
 	}
 }

--- a/src/assets/images/WaterAO.json
+++ b/src/assets/images/WaterAO.json
@@ -5,7 +5,7 @@
 	"frame": {"x":0,"y":0,"w":12,"h":40},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":28,"y":22,"w":12,"h":40},
+	"spriteSourceSize": {"x":28,"y":0,"w":12,"h":40},
 	"sourceSize": {"w":64,"h":64},
 	"pivot": {"x":0.5,"y":0.5}
 },
@@ -14,7 +14,7 @@
 	"frame": {"x":24,"y":16,"w":40,"h":8},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":0,"y":54,"w":40,"h":8},
+	"spriteSourceSize": {"x":0,"y":32,"w":40,"h":8},
 	"sourceSize": {"w":64,"h":64},
 	"pivot": {"x":0.5,"y":0.5}
 },
@@ -23,7 +23,7 @@
 	"frame": {"x":48,"y":24,"w":10,"h":8},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":0,"y":54,"w":10,"h":8},
+	"spriteSourceSize": {"x":0,"y":32,"w":10,"h":8},
 	"sourceSize": {"w":64,"h":64},
 	"pivot": {"x":0.5,"y":0.5}
 },
@@ -32,7 +32,7 @@
 	"frame": {"x":48,"y":32,"w":10,"h":8},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":30,"y":54,"w":10,"h":8},
+	"spriteSourceSize": {"x":30,"y":32,"w":10,"h":8},
 	"sourceSize": {"w":64,"h":64},
 	"pivot": {"x":0.5,"y":0.5}
 },
@@ -41,7 +41,7 @@
 	"frame": {"x":24,"y":24,"w":12,"h":16},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":28,"y":22,"w":12,"h":16},
+	"spriteSourceSize": {"x":28,"y":0,"w":12,"h":16},
 	"sourceSize": {"w":64,"h":64},
 	"pivot": {"x":0.5,"y":0.5}
 },
@@ -50,7 +50,7 @@
 	"frame": {"x":36,"y":24,"w":12,"h":16},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":0,"y":22,"w":12,"h":16},
+	"spriteSourceSize": {"x":0,"y":0,"w":12,"h":16},
 	"sourceSize": {"w":64,"h":64},
 	"pivot": {"x":0.5,"y":0.5}
 },
@@ -59,7 +59,7 @@
 	"frame": {"x":12,"y":0,"w":12,"h":40},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":0,"y":22,"w":12,"h":40},
+	"spriteSourceSize": {"x":0,"y":0,"w":12,"h":40},
 	"sourceSize": {"w":64,"h":64},
 	"pivot": {"x":0.5,"y":0.5}
 },
@@ -68,7 +68,7 @@
 	"frame": {"x":24,"y":0,"w":40,"h":16},
 	"rotated": false,
 	"trimmed": true,
-	"spriteSourceSize": {"x":0,"y":22,"w":40,"h":16},
+	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":16},
 	"sourceSize": {"w":64,"h":64},
 	"pivot": {"x":0.5,"y":0.5}
 }},

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1560,58 +1560,53 @@ module.exports = class LevelView {
 
       atlas = shadowItem.atlas;
       sx = 40 * shadowItem.x;
-      sy = -22 + 40 * shadowItem.y;
+      sy = 40 * shadowItem.y;
 
       if (atlas === 'AO' || atlas === 'blockShadows') {
         switch (shadowItem.type) {
           case "AOeffect_Left":
             sx += 26;
-            sy += 22;
             break;
 
           case "AOeffect_Right":
             sx += 0;
-            sy += 22;
             break;
 
           case "AOeffect_Bottom":
             sx += 0;
-            sy += 22;
             break;
 
           case "AOeffect_BottomLeft":
             sx += 25;
-            sy += 22;
             break;
 
           case "AOeffect_BottomRight":
             sx += 0;
-            sy += 22;
             break;
 
           case "AOeffect_Top":
             sx += 0;
-            sy += 47;
+            sy += 25;
             break;
 
           case "AOeffect_TopLeft":
             sx += 25;
-            sy += 47;
+            sy += 25;
             break;
 
           case "AOeffect_TopRight":
             sx += 0;
-            sy += 47;
+            sy += 25;
             break;
 
           case "Shadow_Parts_Fade_base.png":
             sx -= 52;
-            sy += 0;
+            sy -= 22;
             break;
 
           case "Shadow_Parts_Fade_top.png":
             sx -= 52;
-            sy += 0;
+            sy -= 22;
             break;
         }
       }

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1562,55 +1562,6 @@ module.exports = class LevelView {
       sx = 40 * shadowItem.x;
       sy = 40 * shadowItem.y;
 
-      if (atlas === 'AO' || atlas === 'blockShadows') {
-        switch (shadowItem.type) {
-          case "AOeffect_Left":
-            sx += 25;
-            break;
-
-          case "AOeffect_Right":
-            sx += 0;
-            break;
-
-          case "AOeffect_Bottom":
-            sx += 0;
-            break;
-
-          case "AOeffect_BottomLeft":
-            sx += 25;
-            break;
-
-          case "AOeffect_BottomRight":
-            sx += 0;
-            break;
-
-          case "AOeffect_Top":
-            sx += 0;
-            sy += 25;
-            break;
-
-          case "AOeffect_TopLeft":
-            sx += 25;
-            sy += 25;
-            break;
-
-          case "AOeffect_TopRight":
-            sx += 0;
-            sy += 25;
-            break;
-
-          case "Shadow_Parts_Fade_base.png":
-            sx -= 52;
-            sy -= 22;
-            break;
-
-          case "Shadow_Parts_Fade_top.png":
-            sx -= 52;
-            sy -= 22;
-            break;
-        }
-      }
-
       const sprite = this.shadingGroup.create(sx, sy, atlas, shadowItem.type);
       if (atlas === 'WaterAO') {
         sprite.tint = 0x555555;

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1565,7 +1565,7 @@ module.exports = class LevelView {
       if (atlas === 'AO' || atlas === 'blockShadows') {
         switch (shadowItem.type) {
           case "AOeffect_Left":
-            sx += 26;
+            sx += 25;
             break;
 
           case "AOeffect_Right":


### PR DESCRIPTION
Right now we offset sprites in the atlas JSON, then again in the code.  This PR combines these two offsets and bakes them into the atlas JSON, so no additional adjustment is needed in code.

In the process I found that the `AOeffect_Left` shadow was off by 1px to the east.  Before:

![screen shot 2017-10-30 at 12 45 16 pm](https://user-images.githubusercontent.com/413693/32192763-5a73a424-bd72-11e7-99db-a779f0139a50.png)

Fixed:

![screen shot 2017-10-30 at 12 44 49 pm](https://user-images.githubusercontent.com/413693/32192768-5f9281f0-bd72-11e7-9319-b6bb065695fd.png)