### PR TITLE
Fix levelPlane constructor

### DIFF
--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -35,10 +35,10 @@ module.exports = class LevelModel {
   }
 
   reset() {
-    this.groundPlane = new LevelPlane(this.initialLevelData.groundPlane, this.planeWidth, this.planeHeight, this.controller, this, "groundPlane");
-    this.groundDecorationPlane = new LevelPlane(this.initialLevelData.groundDecorationPlane, this.planeWidth, this.planeHeight, this.controller, this, "decorationPlane");
+    this.groundPlane = new LevelPlane(this.initialLevelData.groundPlane, this.planeWidth, this.planeHeight, this, "groundPlane");
+    this.groundDecorationPlane = new LevelPlane(this.initialLevelData.groundDecorationPlane, this.planeWidth, this.planeHeight, this, "decorationPlane");
     this.shadingPlane = [];
-    this.actionPlane = new LevelPlane(this.initialLevelData.actionPlane, this.planeWidth, this.planeHeight, this.controller, this, "actionPlane");
+    this.actionPlane = new LevelPlane(this.initialLevelData.actionPlane, this.planeWidth, this.planeHeight, this, "actionPlane");
 
     this.actionPlane.powerRedstone();
 

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -45,11 +45,11 @@ const PoweredRailConnectionPriority = [
 ];
 
 module.exports = class LevelPlane {
-  constructor(planeData, width, height, isActionPlane = false, LevelModel = null, planeType = null) {
+  constructor(planeData, width, height, levelModel, planeType) {
     this._data = [];
     this.width = width;
     this.height = height;
-    this.levelModel = LevelModel;
+    this.levelModel = levelModel;
     this.planeType = planeType;
     this.playPistonOn = false;
     this.playPistonOff = false;
@@ -57,7 +57,7 @@ module.exports = class LevelPlane {
     for (let index = 0; index < planeData.length; ++index) {
       let block = new LevelBlock(planeData[index]);
       // TODO(bjordan): put this truth in constructor like other attrs
-      block.isWalkable = block.isWalkable || !isActionPlane;
+      block.isWalkable = block.isWalkable || !this.isActionPlane();
       this._data.push(block);
     }
   }

--- a/test/unit/LevelPlaneTest.js
+++ b/test/unit/LevelPlaneTest.js
@@ -10,7 +10,7 @@ test('get blocks', t => {
     'water', 'lava', 'water', 'lava',
     'grass', 'dirt', 'stone', 'sand',
   ];
-  const plane = new LevelPlane(data, 4, 3, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 4, 3, null, "actionPlane");
 
   t.equal(plane.getBlockAt([0, 0]).blockType, 'grass');
   t.equal(plane.getBlockAt([1, 1], 1).blockType, 'water');
@@ -51,7 +51,7 @@ test('get blocks', t => {
 // 3   │     ──┘
 test('redstone wires', t => {
   const data = new Array(24).fill('');
-  const plane = new LevelPlane(data, 6, 4, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 6, 4, null, "actionPlane");
 
   // Place the test pattern.
   plane.setBlockAt([0, 0], new LevelBlock('redstoneWire'));
@@ -114,7 +114,7 @@ test('rail connections: T-junctions', t => {
     'rails',  '',       'rails',  '',       'rails',  '',       '',
     '',       '',       '',       '',       '',       'rails',  '',
   ];
-  const plane = new LevelPlane(data, 7, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 7, 6, null, "actionPlane");
 
   t.equal(plane.setBlockAt([1, 0], new LevelBlock('rails')).blockType, 'railsSouthEast');
   t.equal(plane.setBlockAt([5, 1], new LevelBlock('rails')).blockType, 'railsSouthEast');
@@ -154,7 +154,7 @@ test('rail connections: unpowered T-junctions', t => {
     'rails',  '',       'rails',  '',       'rails',  '',       '',
     '',       '',       '',       '',       '',       'rails',  '',
   ];
-  const plane = new LevelPlane(data, 7, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 7, 6, null, "actionPlane");
 
   t.equal(plane.setBlockAt([1, 0], new LevelBlock('railsUnpowered')).blockType, 'railsUnpoweredEastWest');
   t.equal(plane.setBlockAt([5, 1], new LevelBlock('railsUnpowered')).blockType, 'railsUnpoweredEastWest');
@@ -184,7 +184,7 @@ test('rail connections: unpowered T-junctions', t => {
 //
 test('rail connections: 2x2 loop', t => {
   const data = new Array(4).fill('');
-  const plane = new LevelPlane(data, 2, 2, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 2, 2, null, "actionPlane");
 
   t.equal(plane.setBlockAt([1, 0], new LevelBlock('rails')).blockType, 'rails');
   t.equal(plane.setBlockAt([0, 0], new LevelBlock('rails')).blockType, 'railsEast');
@@ -209,7 +209,7 @@ test('rail connections: 2x2 loop', t => {
 //    5 6 7       ╚═══╝
 test('rail connections: longer track', t => {
   const data = new Array(16).fill('');
-  const plane = new LevelPlane(data, 4, 4, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 4, 4, null, "actionPlane");
 
   plane.setBlockAt([0, 0], new LevelBlock('rails'));
   plane.setBlockAt([1, 1], new LevelBlock('rails'));
@@ -244,7 +244,7 @@ test('rail connections: longer track', t => {
 //    ║         ║
 test('rail connections: destroy block', t => {
   const data = new Array(9).fill('');
-  const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 3, 3, null, "actionPlane");
 
   plane.setBlockAt([0, 1], new LevelBlock('rails'));
   plane.setBlockAt([1, 1], new LevelBlock('rails'));
@@ -273,7 +273,7 @@ test('rail connections: destroy block', t => {
 //    ║         ║
 test('rail connections: destroy block', t => {
   const data = new Array(9).fill('');
-  const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 3, 3, null, "actionPlane");
 
   plane.setBlockAt([1, 2], new LevelBlock('rails'));
   plane.setBlockAt([1, 1], new LevelBlock('rails'));
@@ -315,7 +315,7 @@ test('redstone charge: place block', t => {
     '','',                        '',
     '','',                        '',
   ];
-  const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 3, 3, null, "actionPlane");
 
   plane.setBlockAt([2, 0], new LevelBlock('redstoneWire'));
   plane.setBlockAt([2, 1], new LevelBlock('redstoneWire'));
@@ -339,7 +339,7 @@ test('powered rails: vertical charge propagation', t => {
     '', 'railsUnpoweredSouth', '',
     '', 'railsUnpoweredNorth', '',
   ];
-  const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 3, 3, null, "actionPlane");
 
   plane.refreshRedstone();
   t.equal(plane.getBlockAt([1, 1]).blockType, "railsPoweredSouth");
@@ -354,7 +354,7 @@ test('powered rails: horizontal charge propagation', t => {
     'railsRedstoneTorch', 'railsUnpoweredEast', 'railsUnpoweredWest',
     '', '', '',
   ];
-  const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 3, 3, null, "actionPlane");
 
   plane.refreshRedstone();
   t.equal(plane.getBlockAt([1, 1]).blockType, "railsPoweredEast");
@@ -389,7 +389,7 @@ test('powered rails: only propagate along straight lines', t => {
     EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, RAILS, EMPTY,
     EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, TORCH, EMPTY,
   ];
-  const plane = new LevelPlane(data, 8, 8, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 8, null, "actionPlane");
 
   t.equal(plane.setBlockAt([2, 1], new LevelBlock('railsUnpowered')).blockType, 'railsPoweredEastWest');
   t.equal(plane.setBlockAt([2, 5], new LevelBlock('railsUnpowered')).blockType, 'railsPoweredEastWest');
@@ -433,7 +433,7 @@ test('redstone charge: destroy block', t => {
     '',                  '',         'redstoneWireVerticalOn',
     'redstoneWire',      '',         'redstoneWireVerticalOn',
   ];
-  const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 3, 3, null, "actionPlane");
 
   plane.setBlockAt([2, 0], new LevelBlock(''));
 
@@ -460,7 +460,7 @@ test('torch charge: destroy block', t => {
     '',                  '',         'redstoneWireVerticalOn',
     'redstoneWire',      '',         'redstoneWireVerticalOn',
   ];
-  const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 3, 3, null, "actionPlane");
 
   plane.setBlockAt([1, 0], new LevelBlock(''));
 
@@ -487,7 +487,7 @@ test('torch charge: place block', t => {
     '',            '',      'redstoneWireVertical',
     '',            '',      'redstoneWireVertical',
   ];
-  const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 3, 3, null, "actionPlane");
 
   plane.setBlockAt([1, 2], new LevelBlock('railsRedstoneTorch'));
 
@@ -508,7 +508,7 @@ test('iron door open: place block', t => {
     'redstoneWireVertical','',      '',
     'doorIron',            '',      'doorIron',
   ];
-  const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 3, 3, null, "actionPlane");
 
   plane.setBlockAt([1, 0], new LevelBlock('railsRedstoneTorch'));
 
@@ -524,7 +524,7 @@ test('iron door close: destroy block', t => {
     'redstoneWireVerticalOn','','',
     'doorIron',              '','doorIron',
   ];
-  const plane = new LevelPlane(data, 3, 3, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 3, 3, null, "actionPlane");
 
   plane.setBlockAt([0, 0], new LevelBlock(''));
 
@@ -543,7 +543,7 @@ test('piston activate: place block', t => {
     '','','','','','','grass','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([4, 2], new LevelBlock('railsRedstoneTorch'));
 
@@ -570,7 +570,7 @@ test('piston deactivate: destroy block', t => {
     '','','','','','','pistonArmDown','',
     '','','','','','','grass','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([4, 2], new LevelBlock(''));
 
@@ -597,7 +597,7 @@ test('sticky piston activate: place block', t => {
     '','','','','','','grass','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([4, 2], new LevelBlock('railsRedstoneTorch'));
 
@@ -624,7 +624,7 @@ test('sticky piston deactivate: destroy block', t => {
     '','','','','','','pistonArmDownSticky','',
     '','','','','','','grass','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([4, 2], new LevelBlock(''));
 
@@ -651,7 +651,7 @@ test('piston destroy torch: adjacent to piston', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([3, 2], new LevelBlock('railsRedstoneTorch'));
 
@@ -678,7 +678,7 @@ test('piston destroy torch: not adjacent to piston', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([3, 2], new LevelBlock('railsRedstoneTorch'));
 
@@ -705,7 +705,7 @@ test('piston destroy door: adjacent to piston', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([3, 2], new LevelBlock('railsRedstoneTorch'));
 
@@ -732,7 +732,7 @@ test('piston destroy door: not adjacent to piston', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([3, 2], new LevelBlock('railsRedstoneTorch'));
 
@@ -759,7 +759,7 @@ test('piston destroy pressure Plate: adjacent to piston', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([3, 2], new LevelBlock('railsRedstoneTorch'));
 
@@ -786,7 +786,7 @@ test('piston destroy door: not adjacent to piston', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([3, 2], new LevelBlock('railsRedstoneTorch'));
 
@@ -813,7 +813,7 @@ test('piston destroy redstoneWire: adjacent to piston', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([3, 2], new LevelBlock('railsRedstoneTorch'));
 
@@ -840,7 +840,7 @@ test('piston destroy redstoneWire: not adjacent to piston', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([3, 2], new LevelBlock('railsRedstoneTorch'));
 
@@ -867,7 +867,7 @@ test('piston directional power: torch at arm side', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([2, 0], new LevelBlock('railsRedstoneTorch'));
 
@@ -894,7 +894,7 @@ test('sticky piston directional power: torch at arm side', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([2, 0], new LevelBlock('railsRedstoneTorch'));
 
@@ -921,7 +921,7 @@ test('certain objets arent weakly charged', t => {
     'pressurePlateUp','','doorIron','','pistonRight','','grass','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([0, 5], new LevelBlock('railsRedstoneTorch'));
   plane.setBlockAt([2, 5], new LevelBlock('railsRedstoneTorch'));
@@ -951,7 +951,7 @@ test('Sticky piston grabbing, do not pull', t => {
     'pistonUpOnSticky','','pistonUpOnSticky','','pistonUpOnSticky','','pistonUpOnSticky','',
     'railsRedstoneTorch','','railsRedstoneTorch','','railsRedstoneTorch','','railsRedstoneTorch','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([0, 5], new LevelBlock(''));
   plane.setBlockAt([2, 5], new LevelBlock(''));
@@ -981,7 +981,7 @@ test('Sticky piston grabbing, do pull', t => {
     'pistonUpOnSticky','','pistonUpOnSticky','','pistonUpOnSticky','','pistonUpOnSticky','',
     'railsRedstoneTorch','','railsRedstoneTorch','','railsRedstoneTorch','','railsRedstoneTorch','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([0, 5], new LevelBlock(''));
   plane.setBlockAt([2, 5], new LevelBlock(''));
@@ -1011,7 +1011,7 @@ test('Weak Charge: placeblock', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([0, 1], new LevelBlock('grass'));
 
@@ -1038,7 +1038,7 @@ test('weak charge: destroy block', t => {
     '','','','','','','','',
     '','','','','','','','',
   ];
-  const plane = new LevelPlane(data, 8, 6, true, null, "actionPlane");
+  const plane = new LevelPlane(data, 8, 6, null, "actionPlane");
 
   plane.setBlockAt([0, 1], new LevelBlock(''));
 


### PR DESCRIPTION
A while ago, we somehow messed up the method signature for the LevelPlane constructor; we were passing in both an `isActionPlane` flag and a `planeType` string (the latter of which is used by the `levelPlane.isActionPlane()` method). We were also for some reason in LevelModel passing in `levelModel.controller` in place of the `isActionPlane` flag.

I've removed the flag and updated the calls in LevelModel and LevelPlaneTest appropriately.

Given that the LevelModel was passing in a truthy value (the controller) for every plane's `isActionPlane` value, next step is to verify that the check we're doing [here](https://github.com/code-dot-org/craft/compare/fix-levelPlane-constructor?expand=1#diff-2365f8601c9dbb7d718e03c8a23baffcR60) is in fact useless