### PR TITLE
can now break glass

### DIFF
--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -85,10 +85,6 @@ module.exports = class LevelBlock {
       this.isEntity = true;
     }
 
-    if (blockType === "glass") {
-      this.isDestroyable = false;
-    }
-
     if (blockType === "bedrock") {
       this.isDestroyable = false;
     }


### PR DESCRIPTION
I'm not sure why glass was made un-breakable, as that doesn't make a ton of sense, but this change -doesn't- break integration tests in any way. Since it doesn't seem to break previous years in any way, I'm looking to fix[ issue 411](https://github.com/code-dot-org/craft/issues/411)