### PR TITLE
phaser CAN crop

### DIFF
--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -209,6 +209,12 @@ module.exports = class LevelBlock {
         this.blockType.startsWith("pressurePlate");
   }
 
+  skipsDestructionOverlay() {
+    return this.isRedstone ||
+      this.blockType === "torch" ||
+      this.blockType === "railsRedstoneTorch";
+  }
+
   shouldRenderOnGroundPlane() {
     return this.isFlat();
   }
@@ -373,6 +379,10 @@ module.exports = class LevelBlock {
    */
   static isFlat(blockType) {
     return new LevelBlock(blockType).isFlat();
+  }
+
+  static skipsDestructionOverlay(blockType) {
+    return new LevelBlock(blockType).skipsDestructionOverlay();
   }
 
   /**

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1156,9 +1156,9 @@ module.exports = class LevelView {
       // block immediately without waiting for the animation.
       afterDestroy();
     } else {
-      let destroyOverlay = this.actionGroup.create(-12 + 40 * destroyPosition[0], -22 + 40 * destroyPosition[1], "destroyOverlay", "destroy1");
+      const destroyOverlay = this.actionGroup.create(-12 + 40 * destroyPosition[0], -22 + 40 * destroyPosition[1], "destroyOverlay", "destroy1");
       if (LevelBlock.isFlat(blockType)) {
-        let cropRect = new Phaser.Rectangle(0, 0, 60, 40);
+        const cropRect = new Phaser.Rectangle(0, 0, 60, 40);
         destroyOverlay.position.y += 20;
         destroyOverlay.crop(cropRect);
       }

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1150,13 +1150,18 @@ module.exports = class LevelView {
       this.playExplosionAnimation(playerPosition, facing, destroyPosition, blockType, completionHandler, true, entity);
     };
 
-    if (LevelBlock.isFlat(blockType)) {
+    if (LevelBlock.skipsDestructionOverlay(blockType)) {
       // "flat" blocks are by definition not cube shaped and so shouldn't accept
       // the cube-shaped destroy overlay animation. In this case, destroy the
       // block immediately without waiting for the animation.
       afterDestroy();
     } else {
-      const destroyOverlay = this.actionGroup.create(-12 + 40 * destroyPosition[0], -22 + 40 * destroyPosition[1], "destroyOverlay", "destroy1");
+      let destroyOverlay = this.actionGroup.create(-12 + 40 * destroyPosition[0], -22 + 40 * destroyPosition[1], "destroyOverlay", "destroy1");
+      if (blockType.startsWith("rails")) {
+        let cropRect = new Phaser.Rectangle(0, 0, 60, 40);
+        destroyOverlay.position.y += 20;
+        destroyOverlay.crop(cropRect);
+      }
       destroyOverlay.sortOrder = this.yToIndex(destroyPosition[1]) + 2;
       this.onAnimationEnd(destroyOverlay.animations.add("destroy", Phaser.Animation.generateFrameNames("destroy", 1, 12, "", 0), 30, false), () => {
         destroyOverlay.kill();

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1157,7 +1157,7 @@ module.exports = class LevelView {
       afterDestroy();
     } else {
       let destroyOverlay = this.actionGroup.create(-12 + 40 * destroyPosition[0], -22 + 40 * destroyPosition[1], "destroyOverlay", "destroy1");
-      if (blockType.startsWith("rails")) {
+      if (LevelBlock.isFlat(blockType)) {
         let cropRect = new Phaser.Rectangle(0, 0, 60, 40);
         destroyOverlay.position.y += 20;
         destroyOverlay.crop(cropRect);


### PR DESCRIPTION
@joshlory or @Hamms 

Phaser can crop the destruction animation! Hurrah!

This crops the destruction overlay to the top 40x40 and then scoots it down 20 pixels so that it lines up over the index the player is destroying so that it can appropriately cover "flat" objects that need an overlay (basically only pressurePlates and rails).

this fixes [issue397](https://github.com/code-dot-org/craft/issues/397)