### PR TITLE
Remove exceptions for Edge in movement listeners

### DIFF
--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -197,10 +197,6 @@ class GameController {
     this.assetLoader.loadPacks(this.levelData.assetPacks.beforeLoad);
   }
 
-  isEdge() {
-    return /Edge\/\d./i.test(navigator.userAgent);
-  }
-
   create() {
     this.levelView.create(this.levelModel);
     this.game.time.slowMotion = this.initialSlowMotion;
@@ -269,10 +265,6 @@ class GameController {
     this.game.input.keyboard.addKey(Phaser.Keyboard.UP).onDown.add(() => {
       this.player.movementState = FacingDirection.North;
       this.player.updateMovement();
-      if (this.isEdge()) {
-        this.player.movementState = -1;
-        this.player.updateMovement();
-      }
     });
     this.game.input.keyboard.addKey(Phaser.Keyboard.UP).onUp.add(() => {
       if (this.player.movementState === FacingDirection.North) {
@@ -283,10 +275,6 @@ class GameController {
     this.game.input.keyboard.addKey(Phaser.Keyboard.W).onDown.add(() => {
       this.player.movementState = FacingDirection.North;
       this.player.updateMovement();
-      if (this.isEdge()) {
-        this.player.movementState = -1;
-        this.player.updateMovement();
-      }
     });
     this.game.input.keyboard.addKey(Phaser.Keyboard.W).onUp.add(() => {
       if (this.player.movementState === FacingDirection.North) {
@@ -297,10 +285,6 @@ class GameController {
     this.game.input.keyboard.addKey(Phaser.Keyboard.RIGHT).onDown.add(() => {
       this.player.movementState = FacingDirection.East;
       this.player.updateMovement();
-      if (this.isEdge()) {
-        this.player.movementState = -1;
-        this.player.updateMovement();
-      }
     });
     this.game.input.keyboard.addKey(Phaser.Keyboard.RIGHT).onUp.add(() => {
       if (this.player.movementState === FacingDirection.East) {
@@ -311,10 +295,6 @@ class GameController {
     this.game.input.keyboard.addKey(Phaser.Keyboard.D).onDown.add(() => {
       this.player.movementState = FacingDirection.East;
       this.player.updateMovement();
-      if (this.isEdge()) {
-        this.player.movementState = -1;
-        this.player.updateMovement();
-      }
     });
     this.game.input.keyboard.addKey(Phaser.Keyboard.D).onUp.add(() => {
       if (this.player.movementState === FacingDirection.East) {
@@ -325,10 +305,6 @@ class GameController {
     this.game.input.keyboard.addKey(Phaser.Keyboard.DOWN).onDown.add(() => {
       this.player.movementState = FacingDirection.South;
       this.player.updateMovement();
-      if (this.isEdge()) {
-        this.player.movementState = -1;
-        this.player.updateMovement();
-      }
     });
     this.game.input.keyboard.addKey(Phaser.Keyboard.DOWN).onUp.add(() => {
       if (this.player.movementState === FacingDirection.South) {
@@ -339,10 +315,6 @@ class GameController {
     this.game.input.keyboard.addKey(Phaser.Keyboard.S).onDown.add(() => {
       this.player.movementState = FacingDirection.South;
       this.player.updateMovement();
-      if (this.isEdge()) {
-        this.player.movementState = -1;
-        this.player.updateMovement();
-      }
     });
     this.game.input.keyboard.addKey(Phaser.Keyboard.S).onUp.add(() => {
       if (this.player.movementState === FacingDirection.South) {
@@ -353,10 +325,6 @@ class GameController {
     this.game.input.keyboard.addKey(Phaser.Keyboard.LEFT).onDown.add(() => {
       this.player.movementState = FacingDirection.West;
       this.player.updateMovement();
-      if (this.isEdge()) {
-        this.player.movementState = -1;
-        this.player.updateMovement();
-      }
     });
     this.game.input.keyboard.addKey(Phaser.Keyboard.LEFT).onUp.add(() => {
       if (this.player.movementState === FacingDirection.West) {
@@ -367,10 +335,6 @@ class GameController {
     this.game.input.keyboard.addKey(Phaser.Keyboard.A).onDown.add(() => {
       this.player.movementState = FacingDirection.West;
       this.player.updateMovement();
-      if (this.isEdge()) {
-        this.agent.movementState = -1;
-        this.agent.updateMovement();
-      }
     });
     this.game.input.keyboard.addKey(Phaser.Keyboard.A).onUp.add(() => {
       if (this.player.movementState === FacingDirection.West) {
@@ -381,10 +345,6 @@ class GameController {
     this.game.input.keyboard.addKey(Phaser.Keyboard.SPACEBAR).onDown.add(() => {
       this.player.movementState = -2;
       this.player.updateMovement();
-      if (this.isEdge()) {
-        this.player.movementState = -1;
-        this.player.updateMovement();
-      }
     });
     this.game.input.keyboard.addKey(Phaser.Keyboard.SPACEBAR).onUp.add(() => {
       if (this.player.movementState === -2) {

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -262,95 +262,31 @@ class GameController {
     if (!this.levelModel.usePlayer) {
       return;
     }
-    this.game.input.keyboard.addKey(Phaser.Keyboard.UP).onDown.add(() => {
-      this.player.movementState = FacingDirection.North;
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.UP).onUp.add(() => {
-      if (this.player.movementState === FacingDirection.North) {
-        this.player.movementState = -1;
-      }
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.W).onDown.add(() => {
-      this.player.movementState = FacingDirection.North;
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.W).onUp.add(() => {
-      if (this.player.movementState === FacingDirection.North) {
-        this.player.movementState = -1;
-      }
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.RIGHT).onDown.add(() => {
-      this.player.movementState = FacingDirection.East;
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.RIGHT).onUp.add(() => {
-      if (this.player.movementState === FacingDirection.East) {
-        this.player.movementState = -1;
-      }
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.D).onDown.add(() => {
-      this.player.movementState = FacingDirection.East;
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.D).onUp.add(() => {
-      if (this.player.movementState === FacingDirection.East) {
-        this.player.movementState = -1;
-      }
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.DOWN).onDown.add(() => {
-      this.player.movementState = FacingDirection.South;
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.DOWN).onUp.add(() => {
-      if (this.player.movementState === FacingDirection.South) {
-        this.player.movementState = -1;
-      }
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.S).onDown.add(() => {
-      this.player.movementState = FacingDirection.South;
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.S).onUp.add(() => {
-      if (this.player.movementState === FacingDirection.South) {
-        this.player.movementState = -1;
-      }
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.LEFT).onDown.add(() => {
-      this.player.movementState = FacingDirection.West;
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.LEFT).onUp.add(() => {
-      if (this.player.movementState === FacingDirection.West) {
-        this.player.movementState = -1;
-      }
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.A).onDown.add(() => {
-      this.player.movementState = FacingDirection.West;
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.A).onUp.add(() => {
-      if (this.player.movementState === FacingDirection.West) {
-        this.player.movementState = -1;
-      }
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.SPACEBAR).onDown.add(() => {
-      this.player.movementState = -2;
-      this.player.updateMovement();
-    });
-    this.game.input.keyboard.addKey(Phaser.Keyboard.SPACEBAR).onUp.add(() => {
-      if (this.player.movementState === -2) {
-        this.player.movementState = -1;
-      }
-      this.player.updateMovement();
+
+    const keysToMovementState = {
+      [Phaser.Keyboard.UP]: FacingDirection.North,
+      [Phaser.Keyboard.W]: FacingDirection.North,
+      [Phaser.Keyboard.RIGHT]: FacingDirection.East,
+      [Phaser.Keyboard.D]: FacingDirection.East,
+      [Phaser.Keyboard.DOWN]: FacingDirection.South,
+      [Phaser.Keyboard.S]: FacingDirection.South,
+      [Phaser.Keyboard.LEFT]: FacingDirection.West,
+      [Phaser.Keyboard.A]: FacingDirection.West,
+      [Phaser.Keyboard.SPACEBAR]: -2
+    };
+
+    Object.keys(keysToMovementState).forEach((key) => {
+      const movementState = keysToMovementState[key];
+      this.game.input.keyboard.addKey(key).onDown.add(() => {
+        this.player.movementState = movementState;
+        this.player.updateMovement();
+      });
+      this.game.input.keyboard.addKey(key).onUp.add(() => {
+        if (this.player.movementState === movementState) {
+          this.player.movementState = -1;
+        }
+        this.player.updateMovement();
+      });
     });
   }
 


### PR DESCRIPTION
Added in 77641b6, we handle movement in Edge differently than in all other browsers. This exception is indirectly responsible for #422, and removing it not only fixes that bug but makes this behave the same in all browsers.

I unfortunately don't know why we added it in the first place, and so I can't be certain that removing it is desirable. @joshlory, thoughts?