### PR TITLE
weird door bug where the animation and the walkability of a door coul…

### DIFF
--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -532,6 +532,9 @@ module.exports = class LevelModel {
     var result = [false,];
 
     if (this.inBounds(position)) {
+      if (this.actionPlane.getBlockAt(position).isOpen) {
+        this.actionPlane.getBlockAt(position).isWalkable = true;
+      }
       if (!this.actionPlane.getBlockAt(position).isWalkable) {
         result.push("notWalkable");
       }


### PR DESCRIPTION
…d become desynched

@joshlory 

This is a weird one, but it pertains to this Trello item:
https://trello.com/c/sNi5uJWW/130-level-2-bug-with-door-to-solve-the-puzzle-cant-walk-through-even-though-it-is-open

This change just asks if the door should be open and sets the walkability to true if that's the case (just in case it wasn't true before).