### PR TITLE
door animation walkability could be desynched

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -2280,7 +2280,7 @@ module.exports = class LevelView {
     const position = this.controller.levelModel.actionPlane.indexToCoordinates(index);
     this.playDoorAnimation(position, open, () => {
       const block = this.controller.levelModel.actionPlane.getBlockAt(position);
-      block.isWalkable = !block.isWalkable;
+      block.isWalkable = block.isOpen;
       if (block.blockType !== "doorIron") {
         // Iron doors don't need to set the player animation to Idle, because they're not opened with 'use'.
         this.playIdleAnimation(player.position, player.facing, player.isOnBlock, player);


### PR DESCRIPTION
Fixing the trello issue:
https://trello.com/c/sNi5uJWW/130-level-2-bug-with-door-to-solve-the-puzzle-cant-walk-through-even-though-it-is-open