### PR TITLE
Agent placeDirection bugged behavior

### DIFF
--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1177,7 +1177,7 @@ class GameController {
     }
 
     position = this.levelModel.getMoveDirectionPosition(player, direction);
-    placementPlane = this.levelModel.getPlaneToPlaceOn(position, player);
+    placementPlane = this.levelModel.getPlaneToPlaceOn(position, player, blockType);
     if (this.levelModel.isBlockOfTypeOnPlane(position, "lava", placementPlane)) {
       soundEffect = () => this.levelView.audioPlayer.play("fizz");
     }

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1191,7 +1191,7 @@ class GameController {
       soundEffect();
 
       this.delayBy(200, () => {
-        this.levelView.playIdleAnimation(this.levelModel.player.position, this.levelModel.player.facing, false);
+        this.levelView.playIdleAnimation(player.position, player.facing, false, player);
       });
       this.delayPlayerMoveBy(200, 400, () => {
         commandQueueItem.succeeded();

--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -358,12 +358,21 @@ module.exports = class LevelBlock {
   }
 
   /**
-   * Static to determine if a block would fall from Action Plane into Ground Plane
+   * Static to determine if a block would fall from Action Plane into Ground Plane.
    * @param {String} blockType
    * @return {boolean}
    */
   static getCanFall(blockType) {
     return new LevelBlock(blockType).getCanFall();
+  }
+
+  /**
+   * Static to determine if a block is placeable over water at all.
+   * @param {String} blockType
+   * @return {boolean}
+   */
+  static getIsPlaceableInLiquid(blockType) {
+    return new LevelBlock(blockType).getIsPlaceableInLiquid();
   }
 
   /**

--- a/src/js/game/LevelMVC/LevelBlock.js
+++ b/src/js/game/LevelMVC/LevelBlock.js
@@ -279,6 +279,11 @@ module.exports = class LevelBlock {
         this.blockType === "lava";
   }
 
+  getCanFall() {
+    return this.blockType === "sand" ||
+        this.blockType === "gravel";
+  }
+
   /**
    * Can this block be placed in liquid to replace a liquid block? Should
    * generally be true for all "standard" blocks like cobblestone and dirt, and
@@ -350,6 +355,15 @@ module.exports = class LevelBlock {
 
   getIsEmptyOrEntity() {
     return this.isEmpty || this.isEntity;
+  }
+
+  /**
+   * Static to determine if a block would fall from Action Plane into Ground Plane
+   * @param {String} blockType
+   * @return {boolean}
+   */
+  static getCanFall(blockType) {
+    return new LevelBlock(blockType).getCanFall();
   }
 
   /**

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -591,7 +591,7 @@ module.exports = class LevelModel {
     if (entity.isOnBlock) {
       return false;
     }
-    let plane = this.getPlaneToPlaceOn(this.getMoveDirectionPosition(entity, direction), entity);
+    let plane = this.getPlaneToPlaceOn(this.getMoveDirectionPosition(entity, direction), entity, blockType);
     if (plane === this.groundPlane) {
       if (LevelBlock.notValidOnGroundPlane(blockType) && this.groundPlane.getBlockAt(this.getMoveDirectionPosition(entity, direction))) {
         return false;
@@ -601,7 +601,7 @@ module.exports = class LevelModel {
     if (this.checkEntityConflict(this.getMoveDirectionPosition(entity, direction))) {
       return false;
     }
-    return this.getPlaneToPlaceOn(this.getMoveDirectionPosition(entity, direction), entity) !== null;
+    return this.getPlaneToPlaceOn(this.getMoveDirectionPosition(entity, direction), entity, blockType) !== null;
   }
 
   checkEntityConflict(position) {
@@ -618,10 +618,14 @@ module.exports = class LevelModel {
     return this.canPlaceBlockDirection(blockType, entity, 0);
   }
 
-  getPlaneToPlaceOn(position, entity) {
+  getPlaneToPlaceOn(position, entity, blockType) {
     if (this.inBounds(position)) {
       let actionBlock = this.actionPlane.getBlockAt(position);
       if (entity === this.agent && actionBlock.isEmpty) {
+        let groundBlock = this.groundPlane.getBlockAt(position);
+        if (groundBlock.getIsLiquid() && LevelBlock.getCanFall(blockType)) {
+          return this.groundPlane;
+        }
         return this.actionPlane;
       }
       if (actionBlock.isPlacable) {

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -623,8 +623,12 @@ module.exports = class LevelModel {
       let actionBlock = this.actionPlane.getBlockAt(position);
       if (entity === this.agent && actionBlock.isEmpty) {
         let groundBlock = this.groundPlane.getBlockAt(position);
-        if (groundBlock.getIsLiquid() && LevelBlock.getCanFall(blockType)) {
-          return this.groundPlane;
+        if (groundBlock.getIsLiquid()) {
+          if (LevelBlock.getCanFall(blockType)) {
+            return this.groundPlane;
+          } else if (!LevelBlock.getIsPlaceableInLiquid(blockType)) {
+            return null;
+          }
         }
         return this.actionPlane;
       }

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -620,10 +620,10 @@ module.exports = class LevelModel {
 
   getPlaneToPlaceOn(position, entity) {
     if (this.inBounds(position)) {
-      if (entity === this.agent) {
+      let actionBlock = this.actionPlane.getBlockAt(position);
+      if (entity === this.agent && actionBlock.isEmpty) {
         return this.actionPlane;
       }
-      let actionBlock = this.actionPlane.getBlockAt(position);
       if (actionBlock.isPlacable) {
         let groundBlock = this.groundPlane.getBlockAt(position);
         if (groundBlock.isPlacable) {


### PR DESCRIPTION
This fixes the bugs with Agent placeDirection:
(1) Agent placeDirection was replacing other blocks in the Action Plane [issue445](https://github.com/code-dot-org/craft/issues/445)
(2) Agent placeDirection was placing sand/gravel in the wrong plane when over water [issue446](https://github.com/code-dot-org/craft/issues/446)

These should both be fixed with this PR.

@joshlory 