### PR TITLE
bounds checking crash on rail riding

### DIFF
--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -771,6 +771,10 @@ module.exports = class LevelView {
   * Handling the first case of walking onto a track while not currently on one
   */
   isFirstTimeOnRails(currPos, nextPos) {
+    if (!this.controller.levelModel.actionPlane.inBounds(currPos) ||
+        !this.controller.levelModel.actionPlane.inBounds(nextPos)) {
+      return false;
+    }
     let nextBlock = this.controller.levelModel.actionPlane.getBlockAt(nextPos);
     let currBlock = this.controller.levelModel.actionPlane.getBlockAt(currPos);
     if (!currBlock.isRail && nextBlock.isRail) {

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -771,13 +771,9 @@ module.exports = class LevelView {
   * Handling the first case of walking onto a track while not currently on one
   */
   isFirstTimeOnRails(currPos, nextPos) {
-    if (!this.controller.levelModel.actionPlane.inBounds(currPos) ||
-        !this.controller.levelModel.actionPlane.inBounds(nextPos)) {
-      return false;
-    }
     let nextBlock = this.controller.levelModel.actionPlane.getBlockAt(nextPos);
     let currBlock = this.controller.levelModel.actionPlane.getBlockAt(currPos);
-    if (!currBlock.isRail && nextBlock.isRail) {
+    if ((nextBlock && currBlock) && (!currBlock.isRail && nextBlock.isRail)) {
       return true;
     }
     return false;


### PR DESCRIPTION
@joshlory  or @Hamms 

Apparently there is a crash when the user:
(1) is riding a rail that leads them right up against the edge of the map (so that the "next index" would be out of bounds)
AND
(2) you destroy the final rail segment after they've begun moving to it (cleared the "next rail" being valid check) but the segment is destroyed by the Agent before the player reaches that index

Whackiness but... it's definitely a bounds check on nextPos there. Figured I'd throw in a bounds check for currPos as well because who knows? Should be impossible but that'll be extra safe.