### PR TITLE
Add ability to create Position instances

### DIFF
--- a/src/js/game/Entities/BaseEntity.js
+++ b/src/js/game/Entities/BaseEntity.js
@@ -307,13 +307,11 @@ module.exports = class BaseEntity {
         this.controller.addCommandRecord("moveAway", this.type, commandQueueItem.repeat);
         var moveAwayPosition = moveAwayFrom.position;
         var bestPosition = [];
-        let absoluteDistanceSquare = function (position1, position2) {
-            return Math.pow(position1[0] - position2[0], 2) + Math.pow(position1[1] - position2[1], 2);
-        };
         let comparePositions = function (moveAwayPosition, position1, position2) {
-            return absoluteDistanceSquare(position1[1], moveAwayPosition) < absoluteDistanceSquare(position2[1], moveAwayPosition) ? position2 : position1;
+            return Position.absoluteDistanceSquare(position1[1], moveAwayPosition) < Position.absoluteDistanceSquare(position2[1], moveAwayPosition) ? position2 : position1;
         };
-        var currentDistance = absoluteDistanceSquare(moveAwayPosition, this.position);
+
+        var currentDistance = Position.absoluteDistanceSquare(moveAwayPosition, this.position);
         // this entity is on the right side and can move to right
         if (moveAwayPosition[0] <= this.position[0] && this.controller.levelModel.canMoveDirection(this, FacingDirection.East)[0]) {
             bestPosition = [FacingDirection.East, [this.position[0] + 1, this.position[1]]];
@@ -343,7 +341,7 @@ module.exports = class BaseEntity {
             }
         }
         // terminate the action since it's impossible to move
-        if (bestPosition.length === 0 || currentDistance >= absoluteDistanceSquare(moveAwayPosition, bestPosition[1])) {
+        if (bestPosition.length === 0 || currentDistance >= Position.absoluteDistanceSquare(moveAwayPosition, bestPosition[1])) {
             commandQueueItem.succeeded();
         } else {
             // execute the best result
@@ -363,11 +361,11 @@ module.exports = class BaseEntity {
         this.controller.addCommandRecord("moveToward", this.type, commandQueueItem.repeat);
         var moveTowardPosition = moveTowardTo.position;
         var bestPosition = [];
-        let absoluteDistanceSquare = function (position1, position2) {
-            return Math.pow(position1[0] - position2[0], 2) + Math.pow(position1[1] - position2[1], 2);
-        };
         let comparePositions = function (moveTowardPosition, position1, position2) {
-            return absoluteDistanceSquare(position1[1], moveTowardPosition) > absoluteDistanceSquare(position2[1], moveTowardPosition) ? position2 : position1;
+          return Position.absoluteDistanceSquare(position1[1], moveTowardPosition) >
+                 Position.absoluteDistanceSquare(position2[1], moveTowardPosition)
+                   ? position2
+                   : position1;
         };
         // this entity is on the right side and can move to right
         if (moveTowardPosition[0] >= this.position[0] && this.controller.levelModel.canMoveDirection(this, FacingDirection.East)[0]) {
@@ -398,8 +396,8 @@ module.exports = class BaseEntity {
             }
         }
         // terminate the action since it's impossible to move
-        if (absoluteDistanceSquare(this.position, moveTowardPosition) === 1) {
-            if (this.position[0] < moveTowardPosition[0]) {
+        if (Position.absoluteDistanceSquare(this.position, moveTowardPosition) === 1) {
+            if (this.position.x < moveTowardPosition.x) {
                 this.facing = FacingDirection.East;
             } else if (this.position[0] > moveTowardPosition[0]) {
                 this.facing = FacingDirection.West;
@@ -425,11 +423,7 @@ module.exports = class BaseEntity {
 
 
     moveTo(commandQueueItem, moveTowardTo) {
-
-        let absoluteDistanceSquare = function (position1, position2) {
-            return Math.sqrt(Math.pow(position1[0] - position2[0], 2) + Math.pow(position1[1] - position2[1], 2));
-        };
-        if (absoluteDistanceSquare(moveTowardTo.position, this.position) === 1) {
+        if (Position.absoluteDistanceSquare(moveTowardTo.position, this.position) === 1) {
             /// north
             if (moveTowardTo.position[1] - this.position[1] === -1) {
                 this.moveDirection(commandQueueItem, FacingDirection.North);
@@ -612,7 +606,7 @@ module.exports = class BaseEntity {
     }
 
     getDistance(entity) {
-        return Math.abs(Math.pow(this.position[0] - entity.position[0], 2) + Math.pow(this.position[1] - entity.position[1], 2));
+      return Position.absoluteDistanceSquare(this.position, entity.position);
     }
 
     blowUp(commandQueueItem, explosionPosition) {

--- a/src/js/game/Entities/BaseEntity.js
+++ b/src/js/game/Entities/BaseEntity.js
@@ -10,7 +10,7 @@ module.exports = class BaseEntity {
     this.queue = new CommandQueue(controller);
     this.controller = controller;
     this.game = controller.game;
-    this.position = [x, y];
+    this.position = new Position(x, y);
     this.type = type;
     // temp
     this.facing = facing;
@@ -152,7 +152,7 @@ module.exports = class BaseEntity {
         const actionPlane = this.controller.levelModel.actionPlane;
 
         let frontBlockCheck = function (entity, position) {
-            let frontPosition = [position[0], position[1] + 1];
+            let frontPosition = Position.south(position);
             const frontBlock = actionPlane.getBlockAt(frontPosition);
             if (frontBlock && !frontBlock.isTransparent) {
                 var sprite = levelView.actionPlaneBlocks[levelView.coordinatesToIndex(frontPosition)];
@@ -167,8 +167,8 @@ module.exports = class BaseEntity {
         };
 
         let prevBlockCheck = function (entity, position) {
-            let frontPosition = [position[0], position[1] + 1];
-            if (frontPosition[1] < 10) {
+            let frontPosition = Position.south(position);
+            if (frontPosition.y < 10) {
                 var sprite = levelView.actionPlaneBlocks[levelView.coordinatesToIndex(frontPosition)];
                 if (sprite !== null) {
                     var tween = entity.controller.levelView.addResettableTween(sprite).to({
@@ -313,31 +313,31 @@ module.exports = class BaseEntity {
 
         var currentDistance = Position.absoluteDistanceSquare(moveAwayPosition, this.position);
         // this entity is on the right side and can move to right
-        if (moveAwayPosition[0] <= this.position[0] && this.controller.levelModel.canMoveDirection(this, FacingDirection.East)[0]) {
-            bestPosition = [FacingDirection.East, [this.position[0] + 1, this.position[1]]];
+        if (moveAwayPosition.x <= this.position.x && this.controller.levelModel.canMoveDirection(this, FacingDirection.East)[0]) {
+            bestPosition = [FacingDirection.East, Position.east(this.position)];
         }
         // this entity is on the left side and can move to left
-        if (moveAwayPosition[0] >= this.position[0] && this.controller.levelModel.canMoveDirection(this, FacingDirection.West)[0]) {
+        if (moveAwayPosition.x >= this.position.x && this.controller.levelModel.canMoveDirection(this, FacingDirection.West)[0]) {
             if (bestPosition.length > 0) {
-                bestPosition = comparePositions(moveAwayPosition, bestPosition, [FacingDirection.West, [this.position[0] - 1, this.position[1]]]);
+                bestPosition = comparePositions(moveAwayPosition, bestPosition, [FacingDirection.West, Position.west(this.position)]);
             } else {
-                bestPosition = [FacingDirection.West, [this.position[0] - 1, this.position[1]]];
+                bestPosition = [FacingDirection.West, Position.west(this.position)];
             }
         }
         // this entity is on the up side and can move to up
-        if (moveAwayPosition[1] >= this.position[1] && this.controller.levelModel.canMoveDirection(this, FacingDirection.North)[0]) {
+        if (moveAwayPosition.y >= this.position.y && this.controller.levelModel.canMoveDirection(this, FacingDirection.North)[0]) {
             if (bestPosition.length > 0) {
-                bestPosition = comparePositions(moveAwayPosition, bestPosition, [FacingDirection.North, [this.position[0], this.position[1] - 1]]);
+                bestPosition = comparePositions(moveAwayPosition, bestPosition, [FacingDirection.North, Position.north(this.position)]);
             } else {
-                bestPosition = [FacingDirection.North, [this.position[0], this.position[1] - 1]];
+                bestPosition = [FacingDirection.North, Position.north(this.position)];
             }
         }
         // this entity is on the down side and can move to down
-        if (moveAwayPosition[1] <= this.position[1] && this.controller.levelModel.canMoveDirection(this, FacingDirection.South)[0]) {
+        if (moveAwayPosition.y <= this.position.y && this.controller.levelModel.canMoveDirection(this, FacingDirection.South)[0]) {
             if (bestPosition.length > 0) {
-                bestPosition = comparePositions(moveAwayPosition, bestPosition, [FacingDirection.South, [this.position[0], this.position[1] + 1]]);
+                bestPosition = comparePositions(moveAwayPosition, bestPosition, [FacingDirection.South, Position.south(this.position)]);
             } else {
-                bestPosition = [FacingDirection.South, [this.position[0], this.position[1] + 1]];
+                bestPosition = [FacingDirection.South, Position.south(this.position)];
             }
         }
         // terminate the action since it's impossible to move
@@ -367,43 +367,44 @@ module.exports = class BaseEntity {
                    ? position2
                    : position1;
         };
+
         // this entity is on the right side and can move to right
-        if (moveTowardPosition[0] >= this.position[0] && this.controller.levelModel.canMoveDirection(this, FacingDirection.East)[0]) {
-            bestPosition = [FacingDirection.East, [this.position[0] + 1, this.position[1]]];
+        if (moveTowardPosition.x >= this.position.x && this.controller.levelModel.canMoveDirection(this, FacingDirection.East)[0]) {
+            bestPosition = [FacingDirection.East, Position.east(this.position)];
         }
         // this entity is on the left side and can move to left
-        if (moveTowardPosition[0] <= this.position[0] && this.controller.levelModel.canMoveDirection(this, FacingDirection.West)[0]) {
+        if (moveTowardPosition.x <= this.position.x && this.controller.levelModel.canMoveDirection(this, FacingDirection.West)[0]) {
             if (bestPosition.length > 0) {
-                bestPosition = comparePositions(moveTowardPosition, bestPosition, [FacingDirection.West, [this.position[0] - 1, this.position[1]]]);
+                bestPosition = comparePositions(moveTowardPosition, bestPosition, [FacingDirection.West, Position.west(this.position)]);
             } else {
-                bestPosition = [FacingDirection.West, [this.position[0] - 1, this.position[1]]];
+                bestPosition = [FacingDirection.West, Position.west(this.position)];
             }
         }
         // this entity is on the up side and can move to up
-        if (moveTowardPosition[1] <= this.position[1] && this.controller.levelModel.canMoveDirection(this, FacingDirection.North)[0]) {
+        if (moveTowardPosition.y <= this.position.y && this.controller.levelModel.canMoveDirection(this, FacingDirection.North)[0]) {
             if (bestPosition.length > 0) {
-                bestPosition = comparePositions(moveTowardPosition, bestPosition, [FacingDirection.North, [this.position[0], this.position[1] - 1]]);
+                bestPosition = comparePositions(moveTowardPosition, bestPosition, [FacingDirection.North, Position.north(this.position)]);
             } else {
-                bestPosition = [FacingDirection.North, [this.position[0], this.position[1] - 1]];
+                bestPosition = [FacingDirection.North, Position.north(this.position)];
             }
         }
         // this entity is on the down side and can move to down
-        if (moveTowardPosition[1] >= this.position[1] && this.controller.levelModel.canMoveDirection(this, FacingDirection.South)[0]) {
+        if (moveTowardPosition.y >= this.position.y && this.controller.levelModel.canMoveDirection(this, FacingDirection.South)[0]) {
             if (bestPosition.length > 0) {
-                bestPosition = comparePositions(moveTowardPosition, bestPosition, [FacingDirection.South, [this.position[0], this.position[1] + 1]]);
+                bestPosition = comparePositions(moveTowardPosition, bestPosition, [FacingDirection.South, Position.south(this.position)]);
             } else {
-                bestPosition = [FacingDirection.South, [this.position[0], this.position[1] + 1]];
+                bestPosition = [FacingDirection.South, Position.south(this.position)];
             }
         }
         // terminate the action since it's impossible to move
         if (Position.absoluteDistanceSquare(this.position, moveTowardPosition) === 1) {
             if (this.position.x < moveTowardPosition.x) {
                 this.facing = FacingDirection.East;
-            } else if (this.position[0] > moveTowardPosition[0]) {
+            } else if (this.position.x > moveTowardPosition.x) {
                 this.facing = FacingDirection.West;
-            } else if (this.position[1] < moveTowardPosition[1]) {
+            } else if (this.position.y < moveTowardPosition.y) {
                 this.facing = FacingDirection.South;
-            } else if (this.position[1] > moveTowardPosition[1]) {
+            } else if (this.position.y > moveTowardPosition.y) {
                 this.facing = FacingDirection.North;
             }
             this.updateAnimationDirection();
@@ -425,11 +426,11 @@ module.exports = class BaseEntity {
     moveTo(commandQueueItem, moveTowardTo) {
         if (Position.absoluteDistanceSquare(moveTowardTo.position, this.position) === 1) {
             /// north
-            if (moveTowardTo.position[1] - this.position[1] === -1) {
+            if (moveTowardTo.position.y - this.position.y === -1) {
                 this.moveDirection(commandQueueItem, FacingDirection.North);
-            } else if (moveTowardTo.position[1] - this.position[1] === 1) {
+            } else if (moveTowardTo.position.y - this.position.y === 1) {
                 this.moveDirection(commandQueueItem, FacingDirection.South);
-            } else if (moveTowardTo.position[0] - this.position[0] === 1) {
+            } else if (moveTowardTo.position.x - this.position.x === 1) {
                 this.moveDirection(commandQueueItem, FacingDirection.East);
             } else {
                 this.moveDirection(commandQueueItem, FacingDirection.West);
@@ -648,7 +649,7 @@ module.exports = class BaseEntity {
   }
 
   handleMoveOffPressurePlate(moveOffset) {
-    const previousPosition = [this.position[0] + moveOffset[0], this.position[1] + moveOffset[1]];
+    const previousPosition = Position.add(this.position, moveOffset);
     const isMovingOffOf = this.controller.levelModel.actionPlane.getBlockAt(previousPosition).blockType === "pressurePlateDown";
     const destinationBlock = this.controller.levelModel.actionPlane.getBlockAt(this.position);
     let remainOn = false;
@@ -670,7 +671,7 @@ module.exports = class BaseEntity {
   }
 
   handleMoveOnPressurePlate(moveOffset) {
-    const targetPosition = [this.position[0] + moveOffset[0], this.position[1] + moveOffset[1]];
+    const targetPosition = Position.add(this.position, moveOffset);
     const isMovingOnToPlate = this.controller.levelModel.actionPlane.getBlockAt(targetPosition).blockType === "pressurePlateUp";
     if (isMovingOnToPlate) {
       this.controller.audioPlayer.play("pressurePlateClick");
@@ -682,7 +683,7 @@ module.exports = class BaseEntity {
   }
 
   handleMoveOffIronDoor(moveOffset) {
-    const formerPosition = [this.position[0] + moveOffset[0], this.position[1] + moveOffset[1]];
+    const formerPosition = Position.add(this.position, moveOffset);
     if (!this.controller.levelModel.inBounds(formerPosition)) {
       return;
     }
@@ -690,12 +691,12 @@ module.exports = class BaseEntity {
     const wasOnDoor = this.controller.levelModel.actionPlane.getBlockAt(formerPosition).blockType === "doorIron";
     const isOnDoor = this.controller.levelModel.actionPlane.getBlockAt(this.position).blockType === "doorIron";
     if (wasOnDoor && !isOnDoor) {
-      this.controller.levelModel.actionPlane.findDoorToAnimate([-1, -1]);
+      this.controller.levelModel.actionPlane.findDoorToAnimate(new Position(-1, -1));
     }
   }
 
   handleMoveAwayFromPiston(moveOffset) {
-    const formerPosition = [this.position[0] + moveOffset[0], this.position[1] + moveOffset[1]];
+    const formerPosition = Position.add(this.position, moveOffset);
     Position.getOrthogonalPositions(formerPosition).forEach(workingPos => {
       if (this.controller.levelModel.actionPlane.inBounds(workingPos)) {
         const block = this.controller.levelModel.actionPlane.getBlockAt(workingPos);
@@ -708,7 +709,7 @@ module.exports = class BaseEntity {
 
   handleGetOnRails(direction) {
     this.getOffTrack = false;
-    this.handleMoveOffPressurePlate([0,0]);
+    this.handleMoveOffPressurePlate(new Position(0, 0));
     this.controller.levelView.playTrack(this.position, direction, true, this, null);
   }
 };

--- a/src/js/game/Entities/Chicken.js
+++ b/src/js/game/Entities/Chicken.js
@@ -2,10 +2,9 @@ const BaseEntity = require("./BaseEntity.js");
 module.exports = class Chicken extends BaseEntity {
     constructor(controller, type, identifier, x, y, facing) {
         super(controller, type, identifier, x, y, facing);
-        var zOrderYIndex = this.position[1];
         this.offset = [-25, -32];
         this.prepareSprite();
-        this.sprite.sortOrder = this.controller.levelView.yToIndex(zOrderYIndex);
+        this.sprite.sortOrder = this.controller.levelView.yToIndex(this.position.y);
     }
 
     prepareSprite() {
@@ -116,7 +115,7 @@ module.exports = class Chicken extends BaseEntity {
         }
         // initialize
         this.controller.levelView.playScaledSpeed(this.sprite.animations, "idle" + this.controller.levelView.getDirectionName(this.facing));
-        this.sprite.x = this.offset[0] + 40 * this.position[0];
-        this.sprite.y = this.offset[1] + 40 * this.position[1];
+        this.sprite.x = this.offset[0] + 40 * this.position.x;
+        this.sprite.y = this.offset[1] + 40 * this.position.y;
     }
 };

--- a/src/js/game/Entities/Cow.js
+++ b/src/js/game/Entities/Cow.js
@@ -2,10 +2,9 @@ const BaseEntity = require("./BaseEntity.js");
 module.exports = class Cow extends BaseEntity {
     constructor(controller, type, identifier, x, y, facing) {
         super(controller, type, identifier, x, y, facing);
-        var zOrderYIndex = this.position[1];
         this.offset = [-43, -55];
         this.prepareSprite();
-        this.sprite.sortOrder = this.controller.levelView.yToIndex(zOrderYIndex);
+        this.sprite.sortOrder = this.controller.levelView.yToIndex(this.position.y);
     }
 
     prepareSprite() {
@@ -142,8 +141,8 @@ module.exports = class Cow extends BaseEntity {
         }
         // initialize
         this.controller.levelView.playScaledSpeed(this.sprite.animations, "idle" + this.controller.levelView.getDirectionName(this.facing));
-        this.sprite.x = this.offset[0] + 40 * this.position[0];
-        this.sprite.y = this.offset[1] + 40 * this.position[1];
+        this.sprite.x = this.offset[0] + 40 * this.position.x;
+        this.sprite.y = this.offset[1] + 40 * this.position.y;
     }
 
     playRandomIdle(facing) {

--- a/src/js/game/Entities/Creeper.js
+++ b/src/js/game/Entities/Creeper.js
@@ -2,10 +2,9 @@ const BaseEntity = require("./BaseEntity.js");
 module.exports = class Creeper extends BaseEntity {
     constructor(controller, type, identifier, x, y, facing) {
         super(controller, type, identifier, x, y, facing);
-        var zOrderYIndex = this.position[1];
         this.offset = [-43, -55];
         this.prepareSprite();
-        this.sprite.sortOrder = this.controller.levelView.yToIndex(zOrderYIndex);
+        this.sprite.sortOrder = this.controller.levelView.yToIndex(this.position.y);
     }
 
     prepareSprite() {
@@ -112,7 +111,7 @@ module.exports = class Creeper extends BaseEntity {
         }
         // initialize
         this.controller.levelView.playScaledSpeed(this.sprite.animations, "idle" + this.controller.levelView.getDirectionName(this.facing));
-        this.sprite.x = this.offset[0] + 40 * this.position[0];
-        this.sprite.y = this.offset[1] + 40 * this.position[1];
+        this.sprite.x = this.offset[0] + 40 * this.position.x;
+        this.sprite.y = this.offset[1] + 40 * this.position.y;
     }
 };

--- a/src/js/game/Entities/Ghast.js
+++ b/src/js/game/Entities/Ghast.js
@@ -68,8 +68,8 @@ module.exports = class Ghast extends BaseEntity {
         }
         // initialize
         this.controller.levelView.playScaledSpeed(this.sprite.animations, "idle" + this.controller.levelView.getDirectionName(this.facing));
-        this.sprite.x = this.offset[0] + 40 * this.position[0];
-        this.sprite.y = this.offset[1] + 40 * this.position[1];
+        this.sprite.x = this.offset[0] + 40 * this.position.x;
+        this.sprite.y = this.offset[1] + 40 * this.position.y;
     }
 
   /**
@@ -122,11 +122,11 @@ module.exports = class Ghast extends BaseEntity {
     const options = [Phaser.Easing.Sinusoidal.InOut, true, 0, -1, true];
 
     this.controller.levelView.addResettableTween(this.sprite).to({
-        y: (this.offset[1] + 40 * this.position[1] + 80),
+        y: (this.offset[1] + 40 * this.position.y + 80),
       }, randomInt(2500, 3500), ...options);
 
     this.controller.levelView.addResettableTween(this.sprite).to({
-        x: (this.offset[0] + 40 * this.position[0] + 10),
+        x: (this.offset[0] + 40 * this.position.x + 10),
       }, randomInt(1500, 2000), ...options);
   }
 
@@ -134,11 +134,11 @@ module.exports = class Ghast extends BaseEntity {
     const options = [Phaser.Easing.Sinusoidal.InOut, true, 0, -1, true];
 
     this.controller.levelView.addResettableTween(this.sprite).to({
-      y: (this.offset[1] + 40 * this.position[1] - 80),
+      y: (this.offset[1] + 40 * this.position.y - 80),
     }, randomInt(2500, 3500), ...options);
 
     this.controller.levelView.addResettableTween(this.sprite).to({
-      x: (this.offset[0] + 40 * this.position[0] - 10),
+      x: (this.offset[0] + 40 * this.position.x - 10),
     }, randomInt(1500, 2000), ...options);
   }
 };

--- a/src/js/game/Entities/IronGolem.js
+++ b/src/js/game/Entities/IronGolem.js
@@ -2,10 +2,9 @@ const BaseEntity = require("./BaseEntity.js");
 module.exports = class IronGolem extends BaseEntity {
     constructor(controller, type, identifier, x, y, facing) {
         super(controller, type, identifier, x, y, facing);
-        var zOrderYIndex = this.position[1];
         this.offset = [-43, -55];
         this.prepareSprite();
-        this.sprite.sortOrder = this.controller.levelView.yToIndex(zOrderYIndex);
+        this.sprite.sortOrder = this.controller.levelView.yToIndex(this.position.y);
     }
 
     prepareSprite() {

--- a/src/js/game/Entities/Player.js
+++ b/src/js/game/Entities/Player.js
@@ -1,5 +1,6 @@
 const BaseEntity = require("./BaseEntity.js");
 const CallbackCommand = require("../CommandQueue/CallbackCommand.js");
+const Position = require("../LevelMVC/Position");
 
 module.exports = class Player extends BaseEntity {
   constructor(controller, type, x, y, name, isOnBlock, facing) {
@@ -219,9 +220,6 @@ module.exports = class Player extends BaseEntity {
   collectItems(targetPosition = this.position) {
     // collectible check
     var collectibles = this.controller.levelView.collectibleItems;
-    var distanceBetween = function (position, position2) {
-      return Math.sqrt(Math.pow(position[0] - position2[0], 2) + Math.pow(position[1] - position2[1], 2));
-    };
     for (var i = 0; i < collectibles.length; i++) {
       const [sprite, offset, blockType, collectibleDistance] = collectibles[i];
       // already collected item
@@ -229,7 +227,7 @@ module.exports = class Player extends BaseEntity {
         collectibles.splice(i, 1);
       } else {
         let collectiblePosition = this.controller.levelModel.spritePositionToIndex(offset, [sprite.x, sprite.y]);
-        if (distanceBetween(targetPosition, collectiblePosition) < collectibleDistance) {
+        if (Position.absoluteDistanceSquare(targetPosition, collectiblePosition) < collectibleDistance) {
           this.controller.levelView.playItemAcquireAnimation(this.position, this.facing, sprite, () => { }, blockType);
           collectibles.splice(i, 1);
         }

--- a/src/js/game/Entities/Sheep.js
+++ b/src/js/game/Entities/Sheep.js
@@ -4,11 +4,10 @@ const EventType = require("../Event/EventType.js");
 module.exports = class Sheep extends BaseEntity {
     constructor(controller, type, identifier, x, y, facing) {
         super(controller, type, identifier, x, y, facing);
-        var zOrderYIndex = this.position[1];
         this.offset = [-43, -55];
         if (this.controller.levelView) {
           this.prepareSprite();
-          this.sprite.sortOrder = this.controller.levelView.yToIndex(zOrderYIndex);
+          this.sprite.sortOrder = this.controller.levelView.yToIndex(this.position.y);
         }
         this.naked = false;
     }
@@ -254,8 +253,8 @@ module.exports = class Sheep extends BaseEntity {
 
         // initialize
         this.controller.levelView.playScaledSpeed(this.sprite.animations, "idle" + this.controller.levelView.getDirectionName(this.facing));
-        this.sprite.x = this.offset[0] + 40 * this.position[0];
-        this.sprite.y = this.offset[1] + 40 * this.position[1];
+        this.sprite.x = this.offset[0] + 40 * this.position.x;
+        this.sprite.y = this.offset[1] + 40 * this.position.y;
     }
 
     playRandomIdle(facing) {

--- a/src/js/game/Entities/Zombie.js
+++ b/src/js/game/Entities/Zombie.js
@@ -64,9 +64,9 @@ module.exports = class Zombie extends BaseEntity {
         var frameName = "Zombie_";
         this.sprite = actionGroup.create(0, 0, 'zombie', 'Zombie_001.png');
         // update sort order and position
-        this.sprite.sortOrder = this.controller.levelView.yToIndex(this.position[1]);
-        this.sprite.x = this.offset[0] + 40 * this.position[0];
-        this.sprite.y = this.offset[1] + 40 * this.position[1];
+        this.sprite.sortOrder = this.controller.levelView.yToIndex(this.position.y);
+        this.sprite.x = this.offset[0] + 40 * this.position.x;
+        this.sprite.y = this.offset[1] + 40 * this.position.y;
         // add burning sprite
         this.burningSprite = [actionGroup.create(this.sprite.x + this.burningSpriteOffset[0], this.sprite.y + this.burningSpriteOffset[1], 'burningInSun', "BurningFront_001.png"),
         actionGroup.create(this.sprite.x + this.burningSpriteOffset[0], this.sprite.y + this.burningSpriteOffset[1], 'burningInSun', "BurningBehind_001.png")];

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1241,7 +1241,7 @@ class GameController {
         const levelEndAnimation = this.levelView.playLevelEndAnimation(player.position, player.facing, player.isOnBlock);
 
         levelEndAnimation.onComplete.add(() => {
-          this.levelModel.spawnAgent(null, [3, 4], 2); // This will spawn the Agent at [3, 4], facing South.
+          this.levelModel.spawnAgent(null, new Position(3, 4), 2); // This will spawn the Agent at [3, 4], facing South.
           this.levelView.agent = this.agent;
           this.levelView.resetEntity(this.agent);
 

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -3,6 +3,7 @@ const CallbackCommand = require("./CommandQueue/CallbackCommand.js");
 
 const EventType = require("./Event/EventType.js");
 const FacingDirection = require("./LevelMVC/FacingDirection.js");
+const Position = require("./LevelMVC/Position.js");
 
 const LevelModel = require("./LevelMVC/LevelModel.js");
 const LevelView = require("./LevelMVC/LevelView.js");
@@ -1209,9 +1210,9 @@ class GameController {
       if (this.checkHouseBuiltEndAnimation()) {
         this.resultReported = true;
         var houseBottomRight = this.levelModel.getHouseBottomRight();
-        var inFrontOfDoor = [houseBottomRight[0] - 1, houseBottomRight[1] + 2];
-        var bedPosition = [houseBottomRight[0], houseBottomRight[1]];
-        var doorPosition = [houseBottomRight[0] - 1, houseBottomRight[1] + 1];
+        var inFrontOfDoor = new Position(houseBottomRight.x - 1, houseBottomRight.y + 2);
+        var bedPosition = new Position(houseBottomRight.x, houseBottomRight.y);
+        var doorPosition = new Position(houseBottomRight.x - 1, houseBottomRight.y + 1);
         this.levelModel.moveTo(inFrontOfDoor);
         this.levelView.playSuccessHouseBuiltAnimation(
           player.position,

--- a/src/js/game/LevelMVC/AStarPathFinding.js
+++ b/src/js/game/LevelMVC/AStarPathFinding.js
@@ -7,7 +7,8 @@ module.exports = class AStarPathFinding {
 
   createGrid() {
     return this.levelModel.actionPlane.getAllPositions().map((position) => {
-      const [x, y] = position;
+      const x = position[0];
+      const y = position[1];
       return {
         x: x,
         y: y,

--- a/src/js/game/LevelMVC/AStarPathFinding.js
+++ b/src/js/game/LevelMVC/AStarPathFinding.js
@@ -1,3 +1,5 @@
+const Position = require("./Position");
+
 module.exports = class AStarPathFinding {
   constructor(model) {
     this.levelModel = model;
@@ -7,11 +9,8 @@ module.exports = class AStarPathFinding {
 
   createGrid() {
     return this.levelModel.actionPlane.getAllPositions().map((position) => {
-      const x = position[0];
-      const y = position[1];
       return {
-        x: x,
-        y: y,
+        position: position,
         cost: 1,    // cost is 1 so that all blocks are treated the same but could do something with lava, water.
         f: 0, g: 0, h: 0, visited: false, closed: false, parent: null
       };
@@ -30,12 +29,6 @@ module.exports = class AStarPathFinding {
     }
   }
 
-  manhattanDistance(a, b) {
-    const d1 = Math.abs (b.x - a.x);
-    const d2 = Math.abs (b.y - a.y);
-    return d1 + d2;
-  }
-
   getNode(position) {
     const index = this.levelModel.coordinatesToIndex(position);
     if (this.levelModel.inBounds(position) &&                        // is the node within bounds
@@ -48,10 +41,10 @@ module.exports = class AStarPathFinding {
 
   getNeighbors(node) {
     let neighbors = [];
-    const west = this.getNode([node.x - 1, node.y]);
-    const east = this.getNode([node.x + 1, node.y]);
-    const south = this.getNode([node.x, node.y - 1]);
-    const north = this.getNode([node.x, node.y + 1]);
+    const west = this.getNode(Position.west(node.position));
+    const east = this.getNode(Position.east(node.position));
+    const south = this.getNode(Position.south(node.position));
+    const north = this.getNode(Position.north(node.position));
 
     // west
     if (west) {
@@ -79,8 +72,8 @@ module.exports = class AStarPathFinding {
     // Ensure we are in a starting state.
     this.reset();
 
-    const startIndex = this.levelModel.coordinatesToIndex(startPosition);
-    const endIndex = this.levelModel.coordinatesToIndex(endPosition);
+    const startIndex = this.levelModel.coordinatesToIndex(startPosition.position);
+    const endIndex = this.levelModel.coordinatesToIndex(endPosition.position);
 
     const endNode = this.grid[endIndex];
 
@@ -127,7 +120,7 @@ module.exports = class AStarPathFinding {
           dirtyFlag = true;
 
           neighbor.visited = true;
-          neighbor.h = this.manhattanDistance(neighbor, endNode);
+          neighbor.h = Position.manhattanDistance(neighbor.position, endNode.position);
           openList.push(neighbor);
         } else if (gScore < neighbor.g) {
           // We've already visited this node, but it now has a better score, let's try it again.

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -31,7 +31,8 @@ module.exports = class LevelModel {
   }
 
   inBounds(position) {
-    const [x, y] = position;
+    const x = position[0];
+    const y = position[1];
     return x >= 0 && x < this.planeWidth && y >= 0 && y < this.planeHeight;
   }
 
@@ -57,7 +58,8 @@ module.exports = class LevelModel {
     this.isDaytime = this.initialLevelData.isDaytime === undefined || this.initialLevelData.isDaytime;
 
     let levelData = Object.create(this.initialLevelData);
-    let [x, y] = levelData.playerStartPosition;
+    let x = levelData.playerStartPosition[0];
+    let y = levelData.playerStartPosition[1];
     if (this.initialLevelData.usePlayer !== undefined) {
       this.usePlayer = this.initialLevelData.usePlayer;
     } else {
@@ -95,7 +97,7 @@ module.exports = class LevelModel {
   spawnAgent(levelData, positionOverride, directionOverride) {
     this.usingAgent = true;
 
-    const [x, y] = (positionOverride !== undefined)
+    const position = (positionOverride !== undefined)
       ? positionOverride
       : levelData.agentStartPosition;
 
@@ -106,8 +108,8 @@ module.exports = class LevelModel {
     const name = "PlayerAgent";
     const key = "Agent";
 
-    const startingBlock = this.actionPlane.getBlockAt([x, y]);
-    this.agent = new Agent(this.controller, name, x, y, key, !startingBlock.getIsEmptyOrEntity(), direction);
+    const startingBlock = this.actionPlane.getBlockAt(position);
+    this.agent = new Agent(this.controller, name, position[0], position[1], key, !startingBlock.getIsEmptyOrEntity(), direction);
     this.controller.levelEntity.pushEntity(this.agent);
     this.controller.agent = this.agent;
   }
@@ -516,16 +518,16 @@ module.exports = class LevelModel {
   }
 
   canMoveForward(entity = this.player) {
-    const [x, y] = this.getMoveForwardPosition(entity);
-    if (!this.controller.followingPlayer() && (x > 9 || y > 9)) {
+    const position = this.getMoveForwardPosition(entity);
+    if (!this.controller.followingPlayer() && (position[0] > 9 || position[1] > 9)) {
       return false;
     }
-    return this.isPositionEmpty([x, y], entity);
+    return this.isPositionEmpty(position, entity);
   }
 
   canMoveBackward(entity = this.player) {
-    const [x, y] = this.getMoveDirectionPosition(entity, 2);
-    return this.isPositionEmpty([x, y], entity);
+    const position = this.getMoveDirectionPosition(entity, 2);
+    return this.isPositionEmpty(position, entity);
   }
 
   isPositionEmpty(position, entity = this.player) {
@@ -734,12 +736,11 @@ module.exports = class LevelModel {
 
   destroyBlock(position) {
     var block = null;
-    let [x, y] = [position[0], position[1]];
 
     if (this.inBounds(position)) {
       block = this.actionPlane.getBlockAt(position);
       if (block !== null) {
-        block.position = [x, y];
+        block.position = position;
 
         if (block.isDestroyable) {
           this.actionPlane.setBlockAt(position, new LevelBlock(""));

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -58,15 +58,22 @@ module.exports = class LevelModel {
     this.isDaytime = this.initialLevelData.isDaytime === undefined || this.initialLevelData.isDaytime;
 
     let levelData = Object.create(this.initialLevelData);
-    let x = levelData.playerStartPosition[0];
-    let y = levelData.playerStartPosition[1];
+    const position = Position.fromArray(levelData.playerStartPosition);
     if (this.initialLevelData.usePlayer !== undefined) {
       this.usePlayer = this.initialLevelData.usePlayer;
     } else {
       this.usePlayer = true;
     }
     if (this.usePlayer) {
-      this.player = new Player(this.controller, "Player", x, y, this.initialLevelData.playerName || "Steve", !this.actionPlane.getBlockAt([x, y]).getIsEmptyOrEntity(), levelData.playerStartDirection);
+      this.player = new Player(
+        this.controller,
+        'Player',
+        position.x,
+        position.y,
+        this.initialLevelData.playerName || 'Steve',
+        !this.actionPlane.getBlockAt(position).getIsEmptyOrEntity(),
+        levelData.playerStartDirection
+      );
       this.controller.levelEntity.pushEntity(this.player);
       this.controller.player = this.player;
 
@@ -99,7 +106,7 @@ module.exports = class LevelModel {
 
     const position = (positionOverride !== undefined)
       ? positionOverride
-      : levelData.agentStartPosition;
+      : Position.fromArray(levelData.agentStartPosition);
 
     const direction = (directionOverride !== undefined)
         ? directionOverride
@@ -109,7 +116,7 @@ module.exports = class LevelModel {
     const key = "Agent";
 
     const startingBlock = this.actionPlane.getBlockAt(position);
-    this.agent = new Agent(this.controller, name, position[0], position[1], key, !startingBlock.getIsEmptyOrEntity(), direction);
+    this.agent = new Agent(this.controller, name, position.x, position.y, key, !startingBlock.getIsEmptyOrEntity(), direction);
     this.controller.levelEntity.pushEntity(this.agent);
     this.controller.agent = this.agent;
   }

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -305,13 +305,12 @@ module.exports = class LevelModel {
     if (!this.usePlayer) {
       return false;
     }
-    return this.player.position[0] === position[0] &&
-      this.player.position[1] === position[1];
+    return Position.equals(this.player.position, position);
   }
 
   spritePositionToIndex(offset, spritePosition) {
-    var position = [spritePosition[0] - offset[0], spritePosition[1] - offset[1]];
-    return [position[0] / 40, position[1] / 40];
+    const position = Position.subtract(spritePosition, offset);
+    return new Position(position.x / 40, position.y / 40);
   }
 
   solutionMapMatchesResultMap(solutionMap) {
@@ -520,7 +519,7 @@ module.exports = class LevelModel {
 
   canMoveForward(entity = this.player) {
     const position = this.getMoveForwardPosition(entity);
-    if (!this.controller.followingPlayer() && (position[0] > 9 || position[1] > 9)) {
+    if (!this.controller.followingPlayer() && (position.x > 9 || position.y > 9)) {
       return false;
     }
     return this.isPositionEmpty(position, entity);
@@ -673,7 +672,7 @@ module.exports = class LevelModel {
   }
 
   moveTo(position, entity = this.player) {
-    entity.setMovePosition(new Position(position[0], position[1]));
+    entity.setMovePosition(position);
 
     if (this.actionPlane.getBlockAt(position).isEmpty) {
       entity.isOnBlock = false;
@@ -900,9 +899,14 @@ module.exports = class LevelModel {
     var emissives = [];
     for (var y = 0; y < this.planeHeight; ++y) {
       for (var x = 0; x < this.planeWidth; ++x) {
-        let position = [x, y];
-        if (!this.actionPlane.getBlockAt(position).isEmpty && this.actionPlane.getBlockAt(position).isEmissive || this.groundPlane.getBlockAt(position).isEmissive && this.actionPlane.getBlockAt(position).isEmpty) {
-          emissives.push([x, y]);
+        let position = new Position(x, y);
+        if (
+          (!this.actionPlane.getBlockAt(position).isEmpty &&
+            this.actionPlane.getBlockAt(position).isEmissive) ||
+          (this.groundPlane.getBlockAt(position).isEmissive &&
+            this.actionPlane.getBlockAt(position).isEmpty)
+        ) {
+          emissives.push(position);
         }
       }
     }

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -141,7 +141,7 @@ module.exports = class LevelModel {
   }
 
   getHouseBottomRight() {
-    return this.initialLevelData.houseBottomRight;
+    return Position.fromArray(this.initialLevelData.houseBottomRight);
   }
 
   // Verifications
@@ -243,7 +243,7 @@ module.exports = class LevelModel {
   }
 
   getNextRailPosition(entity = this.player, direction) {
-    const offset = FacingDirection.directionToOffset(direction) || [0, 0];
+    const offset = FacingDirection.directionToOffset(direction) || new Position(0, 0);
     return Position.add(entity.position, offset);
   }
 
@@ -331,16 +331,10 @@ module.exports = class LevelModel {
   }
 
   getTnt() {
-    var tnt = [];
-    for (var x = 0; x < this.planeWidth; ++x) {
-      for (var y = 0; y < this.planeHeight; ++y) {
-        var block = this.actionPlane.getBlockAt([x, y]);
-        if (block.blockType === "tnt") {
-          tnt.push([x, y]);
-        }
-      }
-    }
-    return tnt;
+    return this.actionPlane.getAllPositions().filter((position) => {
+      const block = this.actionPlane.getBlockAt(position);
+      return (block && block.blockType === "tnt");
+    });
   }
 
   getMoveForwardPosition(entity = this.player) {

--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -672,7 +672,7 @@ module.exports = class LevelModel {
   }
 
   moveTo(position, entity = this.player) {
-    entity.setMovePosition(position);
+    entity.setMovePosition(new Position(position[0], position[1]));
 
     if (this.actionPlane.getBlockAt(position).isEmpty) {
       entity.isOnBlock = false;

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -69,7 +69,8 @@ module.exports = class LevelPlane {
   * Determines whether the position in question is within the bounds of the plane.
   */
   inBounds(position) {
-    const [x, y] = position;
+    const x = position[0];
+    const y = position[1];
     return x >= 0 && x < this.width && y >= 0 && y < this.height;
   }
 

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -87,7 +87,7 @@ module.exports = class LevelPlane {
   indexToCoordinates(index) {
     let y = Math.floor(index / this.width);
     let x = index - (y * this.width);
-    return [x, y];
+    return new Position(x, y);
   }
 
   /**

--- a/src/js/game/LevelMVC/LevelPlane.js
+++ b/src/js/game/LevelMVC/LevelPlane.js
@@ -66,19 +66,22 @@ module.exports = class LevelPlane {
   }
 
   /**
-  * Determines whether the position in question is within the bounds of the plane.
-  */
+   * Determines whether the position in question is within the bounds of the plane.
+   */
   inBounds(position) {
-    const x = position[0];
-    const y = position[1];
-    return x >= 0 && x < this.width && y >= 0 && y < this.height;
+    return (
+      position.x >= 0 &&
+      position.x < this.width &&
+      position.y >= 0 &&
+      position.y < this.height
+    );
   }
 
   /**
-  * Converts coordinates to a index
-  */
+   * Converts coordinates to a index
+   */
   coordinatesToIndex(position) {
-    return position[1] * this.width + position[0];
+    return position.y * this.width + position.x;
   }
 
   /**
@@ -110,6 +113,7 @@ module.exports = class LevelPlane {
    * @return {LevelBlock}
    */
   getBlockAt(position) {
+    position = Position.fromArray(position);
     if (this.inBounds(position)) {
       return this._data[this.coordinatesToIndex(position)];
     }
@@ -132,6 +136,7 @@ module.exports = class LevelPlane {
    * Important note: This is the cornerstone of block placing/destroying.
    */
   setBlockAt(position, block) {
+    position = Position.fromArray(position);
     if (!this.inBounds(position)) {
       return;
     }
@@ -205,14 +210,14 @@ module.exports = class LevelPlane {
    */
   getSurroundingBlocks(position) {
     return {
-      north: this.getBlockAt(Position.add(position, [0, -1])),
-      northEast: this.getBlockAt(Position.add(position, [1, -1])),
-      east: this.getBlockAt(Position.add(position, [1, 0])),
-      southEast: this.getBlockAt(Position.add(position, [1, 1])),
-      south: this.getBlockAt(Position.add(position, [0, 1])),
-      southWest: this.getBlockAt(Position.add(position, [-1, 1])),
-      west: this.getBlockAt(Position.add(position, [-1, 0])),
-      northWest: this.getBlockAt(Position.add(position, [-1, -1])),
+      north: this.getBlockAt(Position.north(position)),
+      northEast: this.getBlockAt(Position.north(Position.east(position))),
+      east: this.getBlockAt(Position.east(position)),
+      southEast: this.getBlockAt(Position.south(Position.east(position))),
+      south: this.getBlockAt(Position.south(position)),
+      southWest: this.getBlockAt(Position.south(Position.west(position))),
+      west: this.getBlockAt(Position.west(position)),
+      northWest: this.getBlockAt(Position.north(Position.west(position))),
     };
   }
 
@@ -475,6 +480,7 @@ module.exports = class LevelPlane {
   * Evaluates what state Iron Doors on the map should be in.
   */
   getIronDoors(position) {
+    position = Position.fromArray(position);
     const block = this.getBlockAt(position);
     const index = this.coordinatesToIndex(position);
 
@@ -681,7 +687,7 @@ module.exports = class LevelPlane {
     }
     let armBlock = new LevelBlock(pistonType);
     for (let i = blocksPositions.length - 1; i >= 0; --i) {
-      let destination = Position.add(blocksPositions[i], offset);
+      let destination = Position.add(blocksPositions[i], Position.fromArray(offset));
       let block = this.getBlockAt(blocksPositions[i]);
       if (this.inBounds(destination) && this.getBlockAt(destination).isDestroyableUponPush()) {
         if (this.levelModel) {
@@ -709,7 +715,7 @@ module.exports = class LevelPlane {
     let workingPosition = position;
     while (this.inBounds(workingPosition) && this.getBlockAt(workingPosition).getIsPushable()) {
       pushingBlocks.push(workingPosition);
-      workingPosition = Position.add(workingPosition, offset);
+      workingPosition = Position.add(workingPosition, Position.fromArray(offset));
     }
     return pushingBlocks;
   }
@@ -726,7 +732,7 @@ module.exports = class LevelPlane {
         }
         if (this.getBlockAt(position).getIsPiston()) {
           const piston = this.getBlockAt(position);
-          const ignoreThisSide = directionToOffset(piston.getPistonDirection()) || [0, 0];
+          const ignoreThisSide = directionToOffset(piston.getPistonDirection()) || new Position(0, 0);
           const posCheck = Position.add(position, ignoreThisSide);
           if (Position.equals(orthogonalPosition, posCheck)) {
             return false;

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -1411,8 +1411,10 @@ module.exports = class LevelView {
    * @return {{x: number, y: number}}
    */
   positionToScreen(position, isOnBlock = false, entity = this.player) {
-    const [x, y] = position;
-    const [xOffset, yOffset] = entity.offset;
+    const x = position[0];
+    const y = position[1];
+    const xOffset = entity.offset[0];
+    const yOffset = entity.offset[1];
     return {
       x: xOffset + 40 * x,
       y: yOffset + (isOnBlock ? -23 : 0) + 40 * y,

--- a/src/js/game/LevelMVC/Position.js
+++ b/src/js/game/LevelMVC/Position.js
@@ -59,6 +59,10 @@ module.exports = class Position {
     return directions.map(direction => Position.forward(position, direction));
   }
 
+  static absoluteDistanceSquare(left, right) {
+    return Math.pow(left[0] - right[0], 2) + Math.pow(left[1] - right[1], 2);
+  }
+
   /**
    * Gets all eight surrounding positions - orthogonal and diagonal
    */

--- a/src/js/game/LevelMVC/Position.js
+++ b/src/js/game/LevelMVC/Position.js
@@ -25,6 +25,10 @@ module.exports = class Position {
     return new Position(left[0] + right[0], left[1] + right[1]);
   }
 
+  static subtract(left, right) {
+    return new Position(left[0] - right[0], left[1] - right[1]);
+  }
+
   static equals(left, right) {
     return left[0] === right[0] && left[1] === right[1];
   }

--- a/src/js/game/LevelMVC/Position.js
+++ b/src/js/game/LevelMVC/Position.js
@@ -80,4 +80,16 @@ module.exports = class Position {
       Position.south(Position.west(position)),
     ]);
   }
+
+  /**
+   * A simple factory method to create Position instances from old [x, y]
+   * position arrays. While we are transitioning fully to Position instances,
+   * this can be used to easily convert from the old form to the new form. Once
+   * we have finished transitioning, this should exclusively be used to parse
+   * position arrays in initial level data into Position instances, and all code
+   * should be using only Position instances.
+   */
+  static fromArray(position) {
+    return new Position(position[0], position[1]);
+  }
 };

--- a/src/js/game/LevelMVC/Position.js
+++ b/src/js/game/LevelMVC/Position.js
@@ -59,6 +59,12 @@ module.exports = class Position {
     return directions.map(direction => Position.forward(position, direction));
   }
 
+  static manhattanDistance(left, right) {
+    const d1 = Math.abs(right.x - left.x);
+    const d2 = Math.abs(right.y - left.y);
+    return d1 + d2;
+  }
+
   static absoluteDistanceSquare(left, right) {
     return Math.pow(left[0] - right[0], 2) + Math.pow(left[1] - right[1], 2);
   }

--- a/src/js/game/LevelMVC/Position.js
+++ b/src/js/game/LevelMVC/Position.js
@@ -9,8 +9,20 @@ const directions = [
 
 module.exports = class Position {
 
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+
+    // Temporarily shadow x and y under array indices, for backwards
+    // compatibility with old [x, y] position arrays.
+    // TODO elijah: remove this once we are fully converted over to actual
+    // Position instances
+    this[0] = x;
+    this[1] = y;
+  }
+
   static add(left, right) {
-    return [left[0] + right[0], left[1] + right[1]];
+    return new Position(left[0] + right[0], left[1] + right[1]);
   }
 
   static equals(left, right) {

--- a/test/integration/AdventurerTest.js
+++ b/test/integration/AdventurerTest.js
@@ -1,10 +1,11 @@
 const test = require("tape");
 const attempt = require("../helpers/RunLevel.js");
+const Position = require("../../src/js/game/LevelMVC/Position");
 
 test('Adventurer 1: Move to Sheep (fail)', t => {
   attempt('adventurer01', api => new Promise(resolve => {
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [3, 4]);
+      t.true(Position.equals(levelModel.player.position, [3, 4]));
       t.assert(!success);
       t.end();
 
@@ -19,7 +20,7 @@ test('Adventurer 1: Move to Sheep (pass)', t => {
     api.moveForward(null, 'Player');
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [5, 4]);
+      t.true(Position.equals(levelModel.player.position, [5, 4]));
       t.assert(success);
       t.end();
 
@@ -35,7 +36,7 @@ test('Adventurer 2: Chop Tree', t => {
     api.destroyBlock(null, 'Player');
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [4, 5]);
+      t.true(Position.equals(levelModel.player.position, [4, 5]));
       t.assert(success);
       t.end();
 
@@ -54,7 +55,7 @@ test('Adventurer 3: Shear Sheep', t => {
     api.use(null, 'Player');
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [4, 4]);
+      t.true(Position.equals(levelModel.player.position, [4, 4]));
       t.assert(success);
       t.end();
 
@@ -74,7 +75,7 @@ test('Adventurer 4: Chop Trees', t => {
     }
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [3, 4]);
+      t.true(Position.equals(levelModel.player.position, [3, 4]));
       t.assert(success);
       t.end();
 
@@ -91,7 +92,7 @@ test('Adventurer 5: Place Wall', t => {
     }
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [2, 6]);
+      t.true(Position.equals(levelModel.player.position, [2, 6]));
       t.assert(success);
       t.end();
 
@@ -111,7 +112,7 @@ test('Adventurer 6: House Frame Chosen', t => {
     }
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [6, 6]);
+      t.true(Position.equals(levelModel.player.position, [6, 6]));
       t.assert(success);
       t.end();
 
@@ -126,7 +127,7 @@ test('Adventurer 7: Plant Crops (fail)', t => {
     api.moveForward(null, 'Player');
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [5, 7]);
+      t.true(Position.equals(levelModel.player.position, [5, 7]));
       t.assert(levelModel.isPlayerStandingInWater());
       t.assert(!success);
       t.end();
@@ -151,7 +152,7 @@ test('Adventurer 7: Plant Crops (pass)', t => {
     }
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [4, 7]);
+      t.true(Position.equals(levelModel.player.position, [4, 7]));
       t.assert(success);
       t.end();
 
@@ -173,7 +174,7 @@ test('Adventurer 8: Avoid Monsters', t => {
     api.moveForward(null, 'Player');
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [4, 2]);
+      t.true(Position.equals(levelModel.player.position, [4, 2]));
       t.assert(success);
       t.end();
 
@@ -192,7 +193,7 @@ test('Adventurer 9: Mining Coal', t => {
     }
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [3, 6]);
+      t.true(Position.equals(levelModel.player.position, [3, 6]));
       t.assert(success);
       t.end();
 
@@ -207,7 +208,7 @@ test('Adventurer 10: Iron (fail)', t => {
     api.moveForward(null, 'Player');
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [3, 4]);
+      t.true(Position.equals(levelModel.player.position, [3, 4]));
       t.assert(levelModel.isPlayerStandingInLava());
       t.assert(!success);
       t.end();
@@ -227,7 +228,7 @@ test('Adventurer 10: Iron (pass)', t => {
     }
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [3, 2]);
+      t.true(Position.equals(levelModel.player.position, [3, 2]));
       t.assert(success);
       t.end();
 
@@ -247,7 +248,7 @@ test('Adventurer 11: Avoiding Lava', t => {
     }
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [8, 4]);
+      t.true(Position.equals(levelModel.player.position, [8, 4]));
       t.assert(success);
       t.end();
 
@@ -270,7 +271,7 @@ test('Adventurer 12: If Statements', t => {
     }
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [3, 2]);
+      t.true(Position.equals(levelModel.player.position, [3, 2]));
       t.assert(success);
       t.end();
 
@@ -290,7 +291,7 @@ test('Adventurer 13: Powered Minecart', t => {
     }
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [11, 7]);
+      t.true(Position.equals(levelModel.player.position, [11, 7]));
       t.assert(success);
       t.end();
 
@@ -309,7 +310,7 @@ test('Adventurer 14: Free Play 20x20', t => {
     api.placeBlock(null, 'tnt', 'Player');
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [7, 9]);
+      t.true(Position.equals(levelModel.player.position, [7, 9]));
       t.assert(success);
       t.end();
 

--- a/test/integration/AgentTest.js
+++ b/test/integration/AgentTest.js
@@ -1,5 +1,6 @@
 const test = require("tape");
 const attempt = require("../helpers/RunLevel.js");
+const Position = require("../../src/js/game/LevelMVC/Position");
 
 test('Agent 1: Leave House', t => {
   attempt('agent01', api => new Promise(resolve => {
@@ -53,9 +54,9 @@ test('Agent 1: Leave House', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.agent.position, [3, 8]);
+      t.true(Position.equals(levelModel.agent.position, [3, 8]));
 
-      t.deepEqual(levelModel.player.position, [8, 8]);
+      t.true(Position.equals(levelModel.player.position, [8, 8]));
       t.assert(success);
       t.end();
 
@@ -100,9 +101,9 @@ test('Agent 2: Open Doors', t => {
     // Check the solutions
     api.startAttempt((success, levelModel) => {
       t.assert(levelModel.usingAgent);
-      t.deepEqual(levelModel.agent.position, [2, 5]);
+      t.true(Position.equals(levelModel.agent.position, [2, 5]));
 
-      t.deepEqual(levelModel.player.position, [6, 1]);
+      t.true(Position.equals(levelModel.player.position, [6, 1]));
       t.assert(success);
       t.end();
 
@@ -153,9 +154,9 @@ test('Agent 3: Open Doors 2.0', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.agent.position, [0, 5]);
+      t.true(Position.equals(levelModel.agent.position, [0, 5]));
 
-      t.deepEqual(levelModel.player.position, [9, 2]);
+      t.true(Position.equals(levelModel.player.position, [9, 2]));
       t.assert(success);
       t.end();
 
@@ -219,9 +220,9 @@ test('Agent 4: Walk on Water', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.agent.position, [3, 1]);
+      t.true(Position.equals(levelModel.agent.position, [3, 1]));
 
-      t.deepEqual(levelModel.player.position, [9, 1]);
+      t.true(Position.equals(levelModel.player.position, [9, 1]));
       t.assert(success);
       t.end();
 
@@ -277,9 +278,9 @@ test('Agent 5: Open Doors 2.0', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.agent.position, [8, 3]);
+      t.true(Position.equals(levelModel.agent.position, [8, 3]));
 
-      t.deepEqual(levelModel.player.position, [9, 1]);
+      t.true(Position.equals(levelModel.player.position, [9, 1]));
       t.assert(success);
       t.end();
 
@@ -330,9 +331,9 @@ test('Agent 6: Build Bridge with one turn', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.agent.position, [5, 3]);
+      t.true(Position.equals(levelModel.agent.position, [5, 3]));
 
-      t.deepEqual(levelModel.player.position, [3, 1]);
+      t.true(Position.equals(levelModel.player.position, [3, 1]));
       t.assert(success);
       t.end();
 
@@ -385,9 +386,9 @@ test('Agent 7: Build Bridge with multiple turns', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.agent.position, [6, 2]);
+      t.true(Position.equals(levelModel.agent.position, [6, 2]));
 
-      t.deepEqual(levelModel.player.position, [5, 1]);
+      t.true(Position.equals(levelModel.player.position, [5, 1]));
       t.assert(success);
       t.end();
 
@@ -435,9 +436,9 @@ test('Agent 8: Build Bridge with Functions', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.agent.position, [7, 7]);
+      t.true(Position.equals(levelModel.agent.position, [7, 7]));
 
-      t.deepEqual(levelModel.player.position, [9, 2]);
+      t.true(Position.equals(levelModel.player.position, [9, 2]));
       t.assert(success);
       t.end();
 
@@ -497,9 +498,9 @@ test('Agent 9: Clear Path', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.agent.position, [8, 3]);
+      t.true(Position.equals(levelModel.agent.position, [8, 3]));
 
-      t.deepEqual(levelModel.player.position, [4, 1]);
+      t.true(Position.equals(levelModel.player.position, [4, 1]));
       t.assert(success);
       t.end();
 
@@ -576,9 +577,9 @@ test('Agent 9: Clear Path', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.agent.position, [9, 2]);
+      t.true(Position.equals(levelModel.agent.position, [9, 2]));
 
-      t.deepEqual(levelModel.player.position, [4, 3]);
+      t.true(Position.equals(levelModel.player.position, [4, 3]));
       t.end();
 
       resolve();
@@ -654,9 +655,9 @@ test('Agent 11: The Nether', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.agent.position, [7, 2]);
+      t.true(Position.equals(levelModel.agent.position, [7, 2]));
 
-      t.deepEqual(levelModel.player.position, [4, 2]);
+      t.true(Position.equals(levelModel.player.position, [4, 2]));
       t.end();
 
       resolve();

--- a/test/integration/DesignerTest.js
+++ b/test/integration/DesignerTest.js
@@ -1,5 +1,6 @@
 const test = require("tape");
 const attempt = require("../helpers/RunLevel.js");
+const Position = require("../../src/js/game/LevelMVC/Position");
 
 test('Designer 1: Chicken Move (fail)', t => {
   attempt('designer01', api => new Promise(resolve => {
@@ -96,7 +97,7 @@ test('Designer 5: Add Shear Sheep Behavior (push back)', t => {
     api.moveForward(null, 'Player');
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [5, 3]);
+      t.true(Position.equals(levelModel.player.position, [5, 3]));
       t.equal(levelModel.getEntityAt([6, 3]), undefined);
       t.equal(levelModel.getEntityAt([7, 3]).type, 'sheep');
       t.assert(!success);
@@ -219,7 +220,7 @@ test('Designer 7: Explode Stone Wall', t => {
     }
 
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [7, 4]);
+      t.true(Position.equals(levelModel.player.position, [7, 4]));
       t.assert(success);
       t.end();
 

--- a/test/integration/FunctionalityTest.js
+++ b/test/integration/FunctionalityTest.js
@@ -1,5 +1,6 @@
 const test = require("tape");
 const attempt = require("../helpers/RunLevel.js");
+const Position = require("../../src/js/game/LevelMVC/Position");
 
 test('Pistons: Entity Obstruction 1', t => {
   attempt('functionality01', api => new Promise(resolve => {
@@ -12,8 +13,8 @@ test('Pistons: Entity Obstruction 1', t => {
     api.startAttempt((success, levelModel) => {
       t.deepEqual(levelModel.actionPlane._data[21].blockType, "");
 
-      t.deepEqual(levelModel.player.position, [4, 3]);
-      t.deepEqual(levelModel.agent.position, [1, 2]);
+      t.true(Position.equals(levelModel.player.position, [4, 3]));
+      t.true(Position.equals(levelModel.agent.position, [1, 2]));
       t.assert(success);
       t.end();
 
@@ -43,8 +44,8 @@ test('Pistons: Entity Obstruction 2', t => {
     api.startAttempt((success, levelModel) => {
       t.deepEqual(levelModel.actionPlane._data[21].blockType, "pistonArmLeft");
 
-      t.deepEqual(levelModel.player.position, [4, 3]);
-      t.deepEqual(levelModel.agent.position, [1, 3]);
+      t.true(Position.equals(levelModel.player.position, [4, 3]));
+      t.true(Position.equals(levelModel.agent.position, [1, 3]));
       t.assert(success);
       t.end();
 
@@ -69,7 +70,7 @@ test('Rails: Moving On to Ride', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [9, 9]);
+      t.true(Position.equals(levelModel.player.position, [9, 9]));
       t.assert(success);
       t.end();
 
@@ -88,7 +89,7 @@ test('Pressure Plate: Moving On to Rail', t => {
 
     // Check the solutions
     api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.player.position, [6, 2]);
+      t.true(Position.equals(levelModel.player.position, [6, 2]));
       t.notOk(levelModel.actionPlane._data[0].isPowered);
       t.assert(success);
       t.end();

--- a/test/unit/LevelViewTest.js
+++ b/test/unit/LevelViewTest.js
@@ -18,6 +18,7 @@ global.Phaser.AnimationManager.prototype.play = () => {};
 const LevelView = require('../../src/js/game/LevelMVC/LevelView');
 const LevelModel = require('../../src/js/game/LevelMVC/LevelModel');
 const LevelEntity = require('../../src/js/game/LevelMVC/LevelEntity');
+const Position = require('../../src/js/game/LevelMVC/Position');
 
 const mockGameController = {
   levelEntity: new LevelEntity({}),
@@ -169,9 +170,9 @@ test('pick up on rails', t => {
         view.createMiniBlock(i, 0, "diamondMiniblock");
       }
 
-      view.player.setMovePosition([0, 0]);
-      view.player.setMovePosition([1, 0]);
-      view.player.setMovePosition([2, 0]);
+      view.player.setMovePosition(new Position(0, 0));
+      view.player.setMovePosition(new Position(1, 0));
+      view.player.setMovePosition(new Position(2, 0));
 
       t.equals(view.collectibleItems.length, 3);
 

--- a/test/unit/PositionTest.js
+++ b/test/unit/PositionTest.js
@@ -3,23 +3,24 @@ const test = require('tape');
 const Position = require("../../src/js/game/LevelMVC/Position");
 
 test('isAdjacent', t => {
-  t.true(Position.isAdjacent([0, 0], [0, 1]));
-  t.true(Position.isAdjacent([0, 0], [1, 0]));
-  t.true(Position.isAdjacent([0, 0], [0, -1]));
-  t.true(Position.isAdjacent([0, 0], [-1, 0]));
+  const center = new Position(0, 0);
+  t.true(Position.isAdjacent(center, new Position(0, 1)));
+  t.true(Position.isAdjacent(center, new Position(1, 0)));
+  t.true(Position.isAdjacent(center, new Position(0, -1)));
+  t.true(Position.isAdjacent(center, new Position(-1, 0)));
 
-  t.false(Position.isAdjacent([0, 0], [-1, -1]));
-  t.false(Position.isAdjacent([0, 0], [1, 1]));
+  t.false(Position.isAdjacent(center, new Position(-1, -1)));
+  t.false(Position.isAdjacent(center, new Position(1, 1)));
 
   t.end();
 });
 
 test('getOrthogonalPositions', t => {
-  t.deepEqual(Position.getOrthogonalPositions([0, 0]), [
-    [0, -1],
-    [1, 0],
-    [0, 1],
-    [-1, 0]
+  t.deepEqual(Position.getOrthogonalPositions(new Position(0, 0)), [
+    new Position(0, -1),
+    new Position(1, 0),
+    new Position(0, 1),
+    new Position(-1, 0)
   ]);
 
   t.end();


### PR DESCRIPTION
new Position instances will have both `instance.x, instance.y` AND
backwards-compatible `instance[0], instance[1]` access options, with the
intention of removing the latter once we can be confident all `[x, y]`
position arrays in the system have been replaced with actual Position
instances.

Note that even with this accomodation, Position instances are not
iterable, so things like `let [x, y] = position` will not work.

General plan of attack for this work-in-progress PR:

- [x] Add new Position instances
- [x] Update everything to use Position instances rather than [x,y] arrays
- [ ] Update static methods like `Position.add` to use `.x` rather than `[0]` access option
- [ ] Remove `[0]` access option
- [ ] Replace static methods like `Position.add(left, right)` with instance methods like `position.add(other)`