### PR TITLE
Add callback for when moveForward() and turn() finish

### DIFF
--- a/src/js/game/API/CodeOrgAPI.js
+++ b/src/js/game/API/CodeOrgAPI.js
@@ -88,7 +88,7 @@ module.exports.get = function (controller) {
     },
 
     moveForward: function (highlightCallback, targetEntity, onFinish) {
-      controller.addCommand(new MoveForwardCommand(controller, highlightCallback, targetEntity), targetEntity, onFinish);
+      controller.addCommand(new MoveForwardCommand(controller, highlightCallback, targetEntity, onFinish), targetEntity);
     },
 
     moveBackward: function (highlightCallback, targetEntity) {

--- a/src/js/game/API/CodeOrgAPI.js
+++ b/src/js/game/API/CodeOrgAPI.js
@@ -87,8 +87,8 @@ module.exports.get = function (controller) {
       controller.addCommand(new MoveDirectionCommand(controller, highlightCallback, targetEntity, direction), targetEntity);
     },
 
-    moveForward: function (highlightCallback, targetEntity) {
-      controller.addCommand(new MoveForwardCommand(controller, highlightCallback, targetEntity), targetEntity);
+    moveForward: function (highlightCallback, targetEntity, onFinish) {
+      controller.addCommand(new MoveForwardCommand(controller, highlightCallback, targetEntity), targetEntity, onFinish);
     },
 
     moveBackward: function (highlightCallback, targetEntity) {
@@ -137,10 +137,10 @@ module.exports.get = function (controller) {
       controller.addCommand(callbackCommand);
     },
 
-    turn: function (highlightCallback, direction, targetEntity) {
+    turn: function (highlightCallback, direction, targetEntity, onFinish) {
       const callbackCommand = new CallbackCommand(controller, highlightCallback, () => {
         controller.turn(callbackCommand, direction === 'right' ? 1 : -1);
-      }, targetEntity);
+      }, targetEntity, onFinish);
       controller.addCommand(callbackCommand);
     },
 

--- a/src/js/game/API/CodeOrgAPI.js
+++ b/src/js/game/API/CodeOrgAPI.js
@@ -151,12 +151,12 @@ module.exports.get = function (controller) {
       controller.addCommand(callbackCommand);
     },
 
-    turnRight: function (highlightCallback, targetEntity) {
-      this.turn(highlightCallback, 'right', targetEntity);
+    turnRight: function (highlightCallback, targetEntity, onFinish) {
+      this.turn(highlightCallback, 'right', targetEntity, onFinish);
     },
 
-    turnLeft: function (highlightCallback, targetEntity) {
-      this.turn(highlightCallback, 'left', targetEntity);
+    turnLeft: function (highlightCallback, targetEntity, onFinish) {
+      this.turn(highlightCallback, 'left', targetEntity, onFinish);
     },
 
     destroyBlock: function (highlightCallback, targetEntity) {

--- a/src/js/game/CommandQueue/BaseCommand.js
+++ b/src/js/game/CommandQueue/BaseCommand.js
@@ -1,12 +1,13 @@
 const CommandState = require("./CommandState.js");
 
 module.exports = class BaseCommand {
-  constructor(gameController, highlightCallback, targetEntity) {
+  constructor(gameController, highlightCallback, targetEntity, onFinish) {
     this.GameController = gameController;
     this.Game = gameController.game;
     this.HighlightCallback = highlightCallback;
     this.state = CommandState.NOT_STARTED;
     this.target = targetEntity;
+    this.onFinish = onFinish;
     this.repeat = false;
   }
 

--- a/src/js/game/CommandQueue/CallbackCommand.js
+++ b/src/js/game/CommandQueue/CallbackCommand.js
@@ -1,8 +1,8 @@
 const BaseCommand = require("./BaseCommand.js");
 
 module.exports = class CallbackCommand extends BaseCommand {
-  constructor(gameController, highlightCallback, actionCallback, targetEntity) {
-    super(gameController, highlightCallback, targetEntity);
+  constructor(gameController, highlightCallback, actionCallback, targetEntity, onFinish) {
+    super(gameController, highlightCallback, targetEntity, onFinish);
     this.actionCallback = actionCallback;
   }
 

--- a/src/js/game/CommandQueue/CommandQueue.js
+++ b/src/js/game/CommandQueue/CommandQueue.js
@@ -95,6 +95,9 @@ module.exports = class CommandQueue {
 
       // check if command is done
       if (this.currentCommand.isSucceeded()) {
+        if (this.currentCommand.onFinish) {
+          this.currentCommand.onFinish();
+        }
         this.currentCommand = null;
       } else if (this.currentCommand.isFailed()) {
         this.state = CommandState.FAILURE;

--- a/src/js/game/CommandQueue/MoveDirectionCommand.js
+++ b/src/js/game/CommandQueue/MoveDirectionCommand.js
@@ -2,7 +2,7 @@ const BaseCommand = require("./BaseCommand.js");
 
 module.exports = class MoveDirectionCommand extends BaseCommand {
   constructor(gameController, highlightCallback, targetEntity, direction) {
-    super(gameController, highlightCallback, targetEntity, direction);
+    super(gameController, highlightCallback, targetEntity);
     this.Direciton = direction;
   }
 

--- a/src/js/game/CommandQueue/MoveForwardCommand.js
+++ b/src/js/game/CommandQueue/MoveForwardCommand.js
@@ -1,8 +1,8 @@
 const BaseCommand = require("./BaseCommand.js");
 
 module.exports = class MoveForwardCommand extends BaseCommand {
-  constructor(gameController, highlightCallback, targetEntity) {
-    super(gameController, highlightCallback, targetEntity);
+  constructor(gameController, highlightCallback, targetEntity, onFinish) {
+    super(gameController, highlightCallback, targetEntity, onFinish);
   }
 
   tick() {

--- a/src/js/game/GameController.js
+++ b/src/js/game/GameController.js
@@ -1284,7 +1284,7 @@ class GameController {
       } else {
         this.endLevel(true);
       }
-    } else if (this.levelModel.isFailed() || !this.getIsDirectPlayerControl()) {
+    } else if (this.levelModel.isFailed() || !(this.getIsDirectPlayerControl() || this.levelData.isAquaticLevel)) {
       // For "Events" levels, check the final state to see if it's failed.
       // Procedural levels only call `checkSolution` after all code has run, so
       // fail if we didn't pass the success condition.


### PR DESCRIPTION
Needed to make these native-is-async in the JS Interpreter.  Even those these functions take a second or so to execute, the JS Interpreter can treat them as synchronous, pausing execution until the callback is called.