### PR TITLE
Smooth prismarine block alpha transition

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -42,6 +42,7 @@
     <option>cobblestone</option>
     <option>pistonRight</option>
     <option>pistonLeft</option>
+    <option>prismarine</option>
   </select>
 </p>
 

--- a/src/js/game/LevelMVC/LevelView.js
+++ b/src/js/game/LevelMVC/LevelView.js
@@ -2309,9 +2309,10 @@ module.exports = class LevelView {
         xOffset = this.blocks[blockType][2];
         yOffset = this.blocks[blockType][3];
         sprite = group.create(xOffset + 40 * x, yOffset + group.yOffset + 40 * y, atlas, frame);
-        frameList = Phaser.Animation.generateFrameNames("Prismarine", 0, 5, "", 0);
-        sprite.animations.add("idle", frameList, 5, true);
-        this.playScaledSpeed(sprite.animations, "idle", 0.1);
+        const options = [1500, Phaser.Easing.Sinusoidal.InOut, true, 0, -1, true];
+        const tween = this.addResettableTween(sprite).to({
+          alpha: 0.5,
+        }, ...options);
         break;
 
       case "seaLantern":


### PR DESCRIPTION
Fixes #480.

We wanted the prismarine block tweens to subtly change color, so this uses a yoyo'd `.to` transition rather than changing step-wise.

### Example
(forgive the dimensions on this gif...)
![prismarine](https://user-images.githubusercontent.com/9812299/46307988-4b494400-c56d-11e8-95a4-c3a20f3608f7.gif)

I set the transition alpha to 0.5, but let me know if that's too drastic of a change!