### PR TITLE
Configure ESLint to allow async/await

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,10 +19,10 @@ module.exports = {
   },
   "parserOptions": {
     "sourceType": "module",
+    "ecmaVersion": 2017,
     "ecmaFeatures": {
       "jsx": true,
       "modules": true,
-      "ecmaVersion": 6,
       "experimentalObjectRestSpread": true
     }
   },

--- a/test/integration/AquaticTest.js
+++ b/test/integration/AquaticTest.js
@@ -3,19 +3,19 @@ const attempt = require("../helpers/RunLevel.js");
 const Position = require("../../src/js/game/LevelMVC/Position");
 
 test('Aquatic 2: Move to boat (pass)', t => {
-  attempt('aquatic02', (api, levelModel) => {
+  attempt('aquatic02', async (api, levelModel) => {
+    t.plan(1);
     const moveForward = () => new Promise(r => api.moveForward(null, 'Player', r));
     const turnRight = () => new Promise(r => api.turnRight(null, 'Player', r));
-    return moveForward()
-      .then(turnRight)
-      .then(moveForward)
-      .then(moveForward)
-      .then(moveForward)
-      .then(moveForward)
-      .then(moveForward)
-      .then(() => {
-        t.deepEqual(levelModel.player.position, new Position(7, 3));
-        t.end();
-      });
+
+    await moveForward();
+    await turnRight();
+    await moveForward();
+    await moveForward();
+    await moveForward();
+    await moveForward();
+    await moveForward();
+
+    t.deepEqual(levelModel.player.position, new Position(7, 3));
   });
 });

--- a/test/integration/DesignerTest.js
+++ b/test/integration/DesignerTest.js
@@ -177,15 +177,15 @@ test('Designer 6: Lead Cows to Grass', t => {
 
 
 test('Designer 7: Cannot walk into lava', t => {
-  attempt('designer07', (api, levelModel) => {
+  attempt('designer07', async (api, levelModel) => {
+    t.plan(1);
     const moveForward = () => new Promise(r => api.moveForward(null, 'Player', r));
     const turnLeft = () => new Promise(r => api.turnLeft(null, 'Player', r));
-    return turnLeft()
-      .then(moveForward)
-      .then(() => {
-        t.true(Position.equals(levelModel.player.position, new Position(3, 1)));
-        t.end();
-      });
+
+    await turnLeft();
+    await moveForward();
+
+    t.true(Position.equals(levelModel.player.position, new Position(3, 1)));
   });
 });
 


### PR DESCRIPTION
Progress on #494: Change ESLint configuration to allow async/await syntax (which we determined yesterday is already supported by your Babel configuration).

Updates a couple of tests from my previous PR to illustrate.