### PR TITLE
Add spawnEntityAt API for use in final Aquatic puzzle

### DIFF
--- a/src/js/game/API/CodeOrgAPI.js
+++ b/src/js/game/API/CodeOrgAPI.js
@@ -206,7 +206,7 @@ module.exports.get = function (controller) {
       });
       controller.addCommand(callbackCommand);
     },
-    spawnEntityAt: function(highlightCallback, type, spawnX, spawnY, spawnDirection) {
+    spawnEntityAt: function (highlightCallback, type, spawnX, spawnY, spawnDirection) {
       var callbackCommand=new CallbackCommand(controller,highlightCallback,() => {
         controller.spawnEntityAt(callbackCommand,type,spawnX,spawnY, spawnDirection);
       });

--- a/src/js/game/API/CodeOrgAPI.js
+++ b/src/js/game/API/CodeOrgAPI.js
@@ -206,7 +206,12 @@ module.exports.get = function (controller) {
       });
       controller.addCommand(callbackCommand);
     },
-
+    spawnEntityAt: function(highlightCallback, type, spawnX, spawnY, spawnDirection) {
+      var callbackCommand=new CallbackCommand(controller,highlightCallback,() => {
+        controller.spawnEntityAt(callbackCommand,type,spawnX,spawnY, spawnDirection);
+      });
+      controller.addCommand(callbackCommand);
+    },
     destroyEntity: function (highlightCallback, targetEntity) {
       var callbackCommand = new CallbackCommand(controller, highlightCallback, () => {
         controller.destroyEntity(callbackCommand, targetEntity);


### PR DESCRIPTION
In the final puzzle, students will be able to place underwater entities. I went to define the new spawn block and realized I could only access `api.spawnEntity()` for spawning entities in imprecise locations. `api.spawnEntityAt()` is needed to allow us to create a block that will enable users to place entities anywhere. 

Not sure whether there's any test coverage needed for these API changes? All I could find was an integration test for `spawnEntity()` from the Designer tutorial.