### PR TITLE
Move all integration tests to new async pattern

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -32,7 +32,7 @@ var gameController = new GameController({
   earlyLoadAssetPacks: testLevelToLoad.earlyLoadAssetPacks,
   earlyLoadNiceToHaveAssetPacks: testLevelToLoad.earlyLoadNiceToHaveAssetPacks,
   afterAssetsLoaded: () => {
-    gameController.codeOrgAPI.startAttempt(() => {});
+    gameController.codeOrgAPI.startAttempt();
   },
 });
 
@@ -54,7 +54,7 @@ $('input[type=range]').on('input', function () {
 
 $('#reset-button').click(function () {
   gameController.codeOrgAPI.resetAttempt();
-  gameController.codeOrgAPI.startAttempt(() => {});
+  gameController.codeOrgAPI.startAttempt();
 });
 
 if (!gameController.levelData.isAgentLevel) {

--- a/src/js/game/API/CodeOrgAPI.js
+++ b/src/js/game/API/CodeOrgAPI.js
@@ -32,6 +32,8 @@ module.exports.get = function (controller) {
     startAttempt: function (onAttemptComplete) {
       return new Promise(resolve => {
         controller.OnCompleteCallback = (...args) => {
+          // Note: onAttemptComplete is unused in this repo, but it's
+          // part of a public API - it'll be a breaking change to remove it.
           onAttemptComplete && onAttemptComplete(...args);
           resolve(args[0]);
         };

--- a/test/integration/AdventurerTest.js
+++ b/test/integration/AdventurerTest.js
@@ -3,50 +3,41 @@ const attempt = require("../helpers/RunLevel.js");
 const Position = require("../../src/js/game/LevelMVC/Position");
 
 test('Adventurer 1: Move to Sheep (fail)', t => {
-  attempt('adventurer01', api => new Promise(resolve => {
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(3, 4)));
-      t.assert(!success);
-      t.end();
-
-      resolve();
-    });
-  }));
+  attempt('adventurer01', async (api, levelModel) => {
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(3, 4)));
+    t.assert(!success);
+    t.end();
+  });
 });
 
 test('Adventurer 1: Move to Sheep (pass)', t => {
-  attempt('adventurer01', api => new Promise(resolve => {
+  attempt('adventurer01', async (api, levelModel) => {
     api.moveForward(null, 'Player');
     api.moveForward(null, 'Player');
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(5, 4)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(5, 4)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 2: Chop Tree', t => {
-  attempt('adventurer02', api => new Promise(resolve => {
+  attempt('adventurer02', async (api, levelModel) => {
     api.moveForward(null, 'Player');
     api.moveForward(null, 'Player');
     api.destroyBlock(null, 'Player');
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(4, 5)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(4, 5)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 3: Shear Sheep', t => {
-  attempt('adventurer03', api => new Promise(resolve => {
+  attempt('adventurer03', async (api, levelModel) => {
     api.moveForward(null, 'Player');
     api.moveForward(null, 'Player');
     api.use(null, 'Player');
@@ -54,18 +45,15 @@ test('Adventurer 3: Shear Sheep', t => {
     api.moveForward(null, 'Player');
     api.use(null, 'Player');
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(4, 4)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(4, 4)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 4: Chop Trees', t => {
-  attempt('adventurer04', api => new Promise(resolve => {
+  attempt('adventurer04', async (api, levelModel) => {
     for (let i = 0; i < 3; i++) {
       api.moveForward(null, 'Player');
       api.moveForward(null, 'Player');
@@ -74,35 +62,29 @@ test('Adventurer 4: Chop Trees', t => {
       api.turnLeft(null, 'Player');
     }
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(3, 4)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(3, 4)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 5: Place Wall', t => {
-  attempt('adventurer05', api => new Promise(resolve => {
+  attempt('adventurer05', async (api, levelModel) => {
     for (let i = 0; i < 4; i++) {
       api.placeBlock(null, 'planksBirch', 'Player');
       api.moveForward(null, 'Player');
     }
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(2, 6)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(2, 6)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 6: House Frame Chosen', t => {
-  attempt('adventurer06', api => new Promise(resolve => {
+  attempt('adventurer06', async (api, levelModel) => {
     for (let i = 0; i < 3; i++) {
       for (let j = 0; j < 3; j++) {
         api.placeBlock(null, 'planksBirch', 'Player');
@@ -111,34 +93,28 @@ test('Adventurer 6: House Frame Chosen', t => {
       api.turnRight(null, 'Player');
     }
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(6, 6)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(6, 6)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 7: Plant Crops (fail)', t => {
-  attempt('adventurer07', api => new Promise(resolve => {
+  attempt('adventurer07', async (api, levelModel) => {
     api.turnRight(null, 'Player');
     api.moveForward(null, 'Player');
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(5, 7)));
-      t.assert(levelModel.isPlayerStandingInWater());
-      t.assert(!success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(5, 7)));
+    t.assert(levelModel.isPlayerStandingInWater());
+    t.assert(!success);
+    t.end();
+  });
 });
 
 test('Adventurer 7: Plant Crops (pass)', t => {
-  attempt('adventurer07', api => new Promise(resolve => {
+  attempt('adventurer07', async (api, levelModel) => {
     for (let i = 0; i < 2; i++) {
       for (let j = 0; j < 6; j++) {
         api.placeBlock(null, 'cropWheat', 'Player');
@@ -151,17 +127,15 @@ test('Adventurer 7: Plant Crops (pass)', t => {
       api.moveForward(null, 'Player');
     }
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(4, 7)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(4, 7)));
+    t.assert(success);
+    t.end();
+  });
 });
+
 test('Adventurer 8: Avoid Monsters', t => {
-  attempt('adventurer08', api => new Promise(resolve => {
+  attempt('adventurer08', async (api, levelModel) => {
     for (let i = 0; i < 4; i++) {
       api.moveForward(null, 'Player');
     }
@@ -173,18 +147,15 @@ test('Adventurer 8: Avoid Monsters', t => {
     api.moveForward(null, 'Player');
     api.moveForward(null, 'Player');
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(4, 2)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(4, 2)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 9: Mining Coal', t => {
-  attempt('adventurer09', api => new Promise(resolve => {
+  attempt('adventurer09', async (api, levelModel) => {
     api.turnLeft(null, 'Player');
     for (let i = 0; i < 2; i++) {
       api.placeBlock(null, 'torch', 'Player');
@@ -192,34 +163,28 @@ test('Adventurer 9: Mining Coal', t => {
       api.moveForward(null, 'Player');
     }
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(3, 6)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(3, 6)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 10: Iron (fail)', t => {
-  attempt('adventurer10', api => new Promise(resolve => {
+  attempt('adventurer10', async (api, levelModel) => {
     api.moveForward(null, 'Player');
     api.moveForward(null, 'Player');
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(3, 4)));
-      t.assert(levelModel.isPlayerStandingInLava());
-      t.assert(!success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(3, 4)));
+    t.assert(levelModel.isPlayerStandingInLava());
+    t.assert(!success);
+    t.end();
+  });
 });
 
 test('Adventurer 10: Iron (pass)', t => {
-  attempt('adventurer10', api => new Promise(resolve => {
+  attempt('adventurer10', async (api, levelModel) => {
     api.moveForward(null, 'Player');
     api.placeInFront(null, 'cobblestone', 'Player');
     for (let i = 0; i < 3; i++) {
@@ -227,18 +192,15 @@ test('Adventurer 10: Iron (pass)', t => {
       api.destroyBlock(null, 'Player');
     }
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(3, 2)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(3, 2)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 11: Avoiding Lava', t => {
-  attempt('adventurer11', api => new Promise(resolve => {
+  attempt('adventurer11', async (api, levelModel) => {
     for (let i = 0; i < 7; i++) {
       api.destroyBlock(null, 'Player');
       api.ifBlockAhead(null, 'lava', 'Player', () => {
@@ -247,18 +209,15 @@ test('Adventurer 11: Avoiding Lava', t => {
       api.moveForward(null, 'Player');
     }
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(8, 4)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(8, 4)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 12: If Statements', t => {
-  attempt('adventurer12', api => new Promise(resolve => {
+  attempt('adventurer12', async (api, levelModel) => {
     for (let i = 0; i < 3; i++) {
       api.moveForward(null, 'Player');
       api.moveForward(null, 'Player');
@@ -270,18 +229,15 @@ test('Adventurer 12: If Statements', t => {
       api.turnLeft(null, 'Player');
     }
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(3, 2)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(3, 2)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 13: Powered Minecart', t => {
-  attempt('adventurer13', api => new Promise(resolve => {
+  attempt('adventurer13', async (api, levelModel) => {
     for (let i = 0; i < 2; i++) {
       api.turnRight(null, 'Player');
       for (let j = 0; j < 6; j++) {
@@ -290,18 +246,15 @@ test('Adventurer 13: Powered Minecart', t => {
       }
     }
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(11, 7)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(11, 7)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Adventurer 14: Free Play 20x20', t => {
-  attempt('adventurer14', api => new Promise(resolve => {
+  attempt('adventurer14', async (api, levelModel) => {
     api.moveForward(null, 'Player');
     api.turnLeft(null, 'Player');
     api.moveForward(null, 'Player');
@@ -309,12 +262,9 @@ test('Adventurer 14: Free Play 20x20', t => {
     api.moveForward(null, 'Player');
     api.placeBlock(null, 'tnt', 'Player');
 
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(7, 9)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(7, 9)));
+    t.assert(success);
+    t.end();
+  });
 });

--- a/test/integration/AgentTest.js
+++ b/test/integration/AgentTest.js
@@ -483,7 +483,7 @@ test('Agent 9: Clear Path', t => {
 });
 
 /*test.only('Agent 10: Ride Rails', t => {
-  attempt('agent10', api => new Promise(resolve => {
+  attempt('agent10', async (api, levelModel) => {
 
     const funcLong = () => {
       for (let i = 0; i < 3; ++i) {
@@ -549,15 +549,12 @@ test('Agent 9: Clear Path', t => {
     }, 28000);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.agent.position, new Position(9, 2)));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.agent.position, new Position(9, 2)));
 
-      t.true(Position.equals(levelModel.player.position, new Position(4, 3)));
-      t.end();
-
-      resolve();
-    });
-  }), 1);
+    t.true(Position.equals(levelModel.player.position, new Position(4, 3)));
+    t.end();
+  }, 1);
 });*/
 
 test('Agent 11: The Nether', t => {

--- a/test/integration/AgentTest.js
+++ b/test/integration/AgentTest.js
@@ -3,7 +3,7 @@ const attempt = require("../helpers/RunLevel.js");
 const Position = require("../../src/js/game/LevelMVC/Position");
 
 test('Agent 1: Leave House', t => {
-  attempt('agent01', api => new Promise(resolve => {
+  attempt('agent01', async (api, levelModel) => {
     // Have the Agent move forward once onto a pressure plate.
     api.moveForward(null, 'PlayerAgent');
 
@@ -53,20 +53,17 @@ test('Agent 1: Leave House', t => {
     }, 1000);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.agent.position, new Position(3, 8)));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.agent.position, new Position(3, 8)));
 
-      t.true(Position.equals(levelModel.player.position, new Position(8, 8)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    t.true(Position.equals(levelModel.player.position, new Position(8, 8)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Agent 2: Open Doors', t => {
-  attempt('agent02', api => new Promise(resolve => {
+  attempt('agent02', async (api, levelModel) => {
 
     // Have the Agent move to the diamond path pressure plate.
     for (let i = 0; i < 4; ++i) {
@@ -99,21 +96,18 @@ test('Agent 2: Open Doors', t => {
     }, 2000);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.assert(levelModel.usingAgent);
-      t.true(Position.equals(levelModel.agent.position, new Position(2, 5)));
+    const success = await api.startAttempt();
+    t.assert(levelModel.usingAgent);
+    t.true(Position.equals(levelModel.agent.position, new Position(2, 5)));
 
-      t.true(Position.equals(levelModel.player.position, new Position(6, 1)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    t.true(Position.equals(levelModel.player.position, new Position(6, 1)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Agent 3: Open Doors 2.0', t => {
-  attempt('agent03', api => new Promise(resolve => {
+  attempt('agent03', async (api, levelModel) => {
 
     // Have the Agent move to the diamond path pressure plate.
     for (let i = 0; i < 4; ++i) {
@@ -153,20 +147,17 @@ test('Agent 3: Open Doors 2.0', t => {
     }, 1000);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.agent.position, new Position(0, 5)));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.agent.position, new Position(0, 5)));
 
-      t.true(Position.equals(levelModel.player.position, new Position(9, 2)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    t.true(Position.equals(levelModel.player.position, new Position(9, 2)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Agent 4: Walk on Water', t => {
-  attempt('agent04', api => new Promise(resolve => {
+  attempt('agent04', async (api, levelModel) => {
 
     // Have the Agent move to the diamond path pressure plate.
     for (let i = 0; i < 6; ++i) {
@@ -219,20 +210,17 @@ test('Agent 4: Walk on Water', t => {
     }, 1000);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.agent.position, new Position(3, 1)));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.agent.position, new Position(3, 1)));
 
-      t.true(Position.equals(levelModel.player.position, new Position(9, 1)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    t.true(Position.equals(levelModel.player.position, new Position(9, 1)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Agent 5: Open Doors 2.0', t => {
-  attempt('agent05', api => new Promise(resolve => {
+  attempt('agent05', async (api, levelModel) => {
 
     // Have the Agent move to the diamond path pressure plate.
     for (let i = 0; i < 5; ++i) {
@@ -277,20 +265,17 @@ test('Agent 5: Open Doors 2.0', t => {
     }, 1500);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.agent.position, new Position(8, 3)));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.agent.position, new Position(8, 3)));
 
-      t.true(Position.equals(levelModel.player.position, new Position(9, 1)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    t.true(Position.equals(levelModel.player.position, new Position(9, 1)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Agent 6: Build Bridge with one turn', t => {
-  attempt('agent06', api => new Promise(resolve => {
+  attempt('agent06', async (api, levelModel) => {
     // Have the Agent build a bridge.
     for (let i = 0; i < 3; i++) {
       api.moveForward(null, 'PlayerAgent');
@@ -330,20 +315,17 @@ test('Agent 6: Build Bridge with one turn', t => {
     }, 1000);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.agent.position, new Position(5, 3)));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.agent.position, new Position(5, 3)));
 
-      t.true(Position.equals(levelModel.player.position, new Position(3, 1)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    t.true(Position.equals(levelModel.player.position, new Position(3, 1)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Agent 7: Build Bridge with multiple turns', t => {
-  attempt('agent07', api => new Promise(resolve => {
+  attempt('agent07', async (api, levelModel) => {
     // Have the Agent build a bridge.
     for (let i = 0; i < 3; i++) {
       api.moveForward(null, 'PlayerAgent');
@@ -385,20 +367,17 @@ test('Agent 7: Build Bridge with multiple turns', t => {
     }, 1000);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.agent.position, new Position(6, 2)));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.agent.position, new Position(6, 2)));
 
-      t.true(Position.equals(levelModel.player.position, new Position(5, 1)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    t.true(Position.equals(levelModel.player.position, new Position(5, 1)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Agent 8: Build Bridge with Functions', t => {
-  attempt('agent08', api => new Promise(resolve => {
+  attempt('agent08', async (api, levelModel) => {
 
     const func = () => {
       for (let i = 0; i < 2; ++i) {
@@ -435,20 +414,17 @@ test('Agent 8: Build Bridge with Functions', t => {
     }, 10000);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.agent.position, new Position(7, 7)));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.agent.position, new Position(7, 7)));
 
-      t.true(Position.equals(levelModel.player.position, new Position(9, 2)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    t.true(Position.equals(levelModel.player.position, new Position(9, 2)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Agent 9: Clear Path', t => {
-  attempt('agent09', api => new Promise(resolve => {
+  attempt('agent09', async (api, levelModel) => {
 
     const func = () => {
       api.destroyBlock(null, 'PlayerAgent');
@@ -497,16 +473,13 @@ test('Agent 9: Clear Path', t => {
     }, 5000);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.agent.position, new Position(8, 3)));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.agent.position, new Position(8, 3)));
 
-      t.true(Position.equals(levelModel.player.position, new Position(4, 1)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    t.true(Position.equals(levelModel.player.position, new Position(4, 1)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 /*test.only('Agent 10: Ride Rails', t => {
@@ -588,7 +561,7 @@ test('Agent 9: Clear Path', t => {
 });*/
 
 test('Agent 11: The Nether', t => {
-  attempt('agent11', api => new Promise(resolve => {
+  attempt('agent11', async (api, levelModel) => {
 
     const funcLong = () => {
       for (let i = 0; i < 5; ++i) {
@@ -654,14 +627,11 @@ test('Agent 11: The Nether', t => {
     }, 15000);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.agent.position, new Position(7, 2)));
+    await api.startAttempt();
+    t.true(Position.equals(levelModel.agent.position, new Position(7, 2)));
 
-      t.true(Position.equals(levelModel.player.position, new Position(4, 2)));
-      t.end();
-
-      resolve();
-    });
-  }));
+    t.true(Position.equals(levelModel.player.position, new Position(4, 2)));
+    t.end();
+  });
 });
 

--- a/test/integration/FunctionalityTest.js
+++ b/test/integration/FunctionalityTest.js
@@ -3,28 +3,25 @@ const attempt = require("../helpers/RunLevel.js");
 const Position = require("../../src/js/game/LevelMVC/Position");
 
 test('Pistons: Entity Obstruction 1', t => {
-  attempt('functionality01', api => new Promise(resolve => {
+  attempt('functionality01', async (api, levelModel) => {
     // Power the piston
     api.placeInFront(null, 'railsRedstoneTorch', 'Player');
     api.turnLeft(null, 'Player');
     api.moveForward(null, 'Player');
 
     // Check the solutions. No piston arm should exist because Agent conflicts with the index
-    api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.actionPlane._data[21].blockType, "");
+    const success = await api.startAttempt();
+    t.deepEqual(levelModel.actionPlane._data[21].blockType, "");
 
-      t.true(Position.equals(levelModel.player.position, new Position(4, 3)));
-      t.true(Position.equals(levelModel.agent.position, new Position(1, 2)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }), 1);
+    t.true(Position.equals(levelModel.player.position, new Position(4, 3)));
+    t.true(Position.equals(levelModel.agent.position, new Position(1, 2)));
+    t.assert(success);
+    t.end();
+  }, 1);
 });
 
 test('Pistons: Entity Obstruction 2', t => {
-  attempt('functionality01', api => new Promise(resolve => {
+  attempt('functionality01', async (api, levelModel) => {
     // Power the piston
     api.placeInFront(null, 'railsRedstoneTorch', 'Player');
     api.turnLeft(null, 'Player');
@@ -41,21 +38,18 @@ test('Pistons: Entity Obstruction 2', t => {
     }, 2000);
 
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.deepEqual(levelModel.actionPlane._data[21].blockType, "pistonArmLeft");
+    const success = await api.startAttempt();
+    t.deepEqual(levelModel.actionPlane._data[21].blockType, "pistonArmLeft");
 
-      t.true(Position.equals(levelModel.player.position, new Position(4, 3)));
-      t.true(Position.equals(levelModel.agent.position, new Position(1, 3)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }), 1);
+    t.true(Position.equals(levelModel.player.position, new Position(4, 3)));
+    t.true(Position.equals(levelModel.agent.position, new Position(1, 3)));
+    t.assert(success);
+    t.end();
+  }, 1);
 });
 
 test('Rails: Moving On to Ride', t => {
-  attempt('functionality02', api => new Promise(resolve => {
+  attempt('functionality02', async (api, levelModel) => {
 
     // Have the player walk onto the rails and ride them to the end of the track.
     api.moveDirection(null, 'Player', 1);
@@ -67,35 +61,27 @@ test('Rails: Moving On to Ride', t => {
       }
     }, 10000);
 
-
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(9, 9)));
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(9, 9)));
+    t.assert(success);
+    t.end();
+  });
 });
 
 test('Pressure Plate: Moving On to Rail', t => {
-  attempt('functionality03', api => new Promise(resolve => {
+  attempt('functionality03', async (api, levelModel) => {
 
     // Have the player walk onto the rails and ride them to the end of the track.
     api.moveDirection(null, 'Player', 2);
     api.moveDirection(null, 'Player', 1);
 
-
     // Check the solutions
-    api.startAttempt((success, levelModel) => {
-      t.true(Position.equals(levelModel.player.position, new Position(6, 2)));
-      t.notOk(levelModel.actionPlane._data[0].isPowered);
-      t.assert(success);
-      t.end();
-
-      resolve();
-    });
-  }));
+    const success = await api.startAttempt();
+    t.true(Position.equals(levelModel.player.position, new Position(6, 2)));
+    t.notOk(levelModel.actionPlane._data[0].isPowered);
+    t.assert(success);
+    t.end();
+  });
 });
 


### PR DESCRIPTION
Fixes #494. Follow-on to work in https://github.com/code-dot-org/craft/pull/495 and https://github.com/code-dot-org/craft/pull/498.

Applies new async/await pattern to all integration tests, completely removing the internal dependency on the `onAttemptComplete` callback argument to `startAttempt`.  However, I'm not entirely removing this argument yet - it's part of a public API and is still used in the main `code-dot-org/code-dot-org` repo.