### PR TITLE
Update the demo to work in IE11

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -31,7 +31,7 @@ var gameController = new GameController({
   debug: true,
   earlyLoadAssetPacks: testLevelToLoad.earlyLoadAssetPacks,
   earlyLoadNiceToHaveAssetPacks: testLevelToLoad.earlyLoadNiceToHaveAssetPacks,
-  afterAssetsLoaded: () => {
+  afterAssetsLoaded: function () {
     gameController.codeOrgAPI.startAttempt();
   },
 });
@@ -39,12 +39,12 @@ var gameController = new GameController({
 gameController.loadLevel(testLevelToLoad);
 
 var $levelselect = $('#level-load');
-Object.keys(levels).forEach(key => {
+Object.keys(levels).forEach(function (key) {
   $levelselect.append($('<option/>', {text: key, selected: key === levelParam}));
 });
 
-$levelselect.on('change', () => {
-  location.search = `level=${$levelselect.val()}`;
+$levelselect.on('change', function () {
+  location.search = 'level=' + $levelselect.val();
 });
 
 $('input[type=range]').on('input', function () {
@@ -61,7 +61,7 @@ if (!gameController.levelData.isAgentLevel) {
   $('#entity-select').hide();
 }
 
-window.addEventListener('keydown', e => {
+window.addEventListener('keydown', function (e) {
   if (e.target !== document.body) {
     e.preventDefault();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1429,6 +1429,25 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babelify": "^6.3.0",
     "browserify": "^10.2.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import 'babel-polyfill';
+
 const GameController = require("./js/game/GameController");
 const FacingDirection = require("./js/game/LevelMVC/FacingDirection");
 const EventType = require("./js/game/Event/EventType");


### PR DESCRIPTION
I don't think we'll want to merge this until we _also_ ship the unbuild files to npm. Otherwise we'll double-include the `babel-polyfill` when importing the built `dist/main.js` in the main repo.