### PR TITLE
[Minecraft] Check for walkable space above water and lava

### DIFF
--- a/src/js/game/LevelMVC/LevelModel.js
+++ b/src/js/game/LevelMVC/LevelModel.js
@@ -583,7 +583,8 @@ module.exports = class LevelModel {
       // blocks, let them drown.
       const blockTypeAtPosition = this.groundPlane.getBlockAt(position).blockType;
       const frontEntity = this.getEntityAt(position);
-      if (['water', 'lava'].includes(blockTypeAtPosition)) {
+      const isWalkable = this.actionPlane.getBlockAt(position).isWalkable;
+      if (['water', 'lava'].includes(blockTypeAtPosition) && isWalkable) {
         if (this.controller.getIsDirectPlayerControl()) {
           result.push(blockTypeAtPosition);
         } else if (frontEntity === undefined || frontEntity.canMoveThrough()) {


### PR DESCRIPTION
In a few Minecraft levels, lava tiles on the ground plane are covered by a solid block on the action plane. We haven't actually been checking for these solid blocks when determining if the player should fall into the lava (or water). As a consequence of this, it was actually possible to walk through these blocks rather than bump into them. As it turns out, we can easily check whether the space ahead is "walkable" by looking at the action plane, and consider that before determining if a player should in fact drown.

**Before:**

https://user-images.githubusercontent.com/43474485/190183479-98be601d-2029-43be-ad5b-817554bd0f19.mp4


**After:**

https://user-images.githubusercontent.com/43474485/190183499-efa614c6-96b4-42aa-ad78-bef0bf3d3129.mp4


I tested this change across Minecraft Adventurer and Minecraft Aquatic levels and couldn't find any unexpected behaviors.

ZenDesk ticket: https://codeorg.zendesk.com/agent/tickets/396600
Jira Issue: https://codedotorg.atlassian.net/browse/STAR-2405